### PR TITLE
fix(DicomReceiver): suppress late dcmrecv events after finalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **DicomReceiver: late `ASSOCIATION_RECEIVED` re-registered an already-finalized association.** After the worker double-assignment race was fixed (0.16.0), an end-to-end soak under extreme concurrency (50 parallel single-file associations) left a small residual — ~1 in 1500 associations un-finalized from the consumer's view (realistic batched traffic was fully clean). dcmrecv's stdout can deliver a stray `ASSOCIATION_RECEIVED` for an association _after_ the worker has already finalized it and gone idle; the pool bubbled it, so a consumer registered an association that never got a matching `ASSOCIATION_FINALIZED`. Fixed by suppressing `ASSOCIATION_RECEIVED` when `worker.finalized` is set — the flag stays true between finalize and the next `beginAssociation` (which resets it before a genuinely new association's events arrive), so only strays are filtered. The event carries no payload, so suppression is non-destructive. **`FILE_RECEIVED` is deliberately _not_ suppressed**: it represents an object already written to disk, and a `FILE_RECEIVED` arriving after finalize indicates finalization fired too early (a drain/stream-ordering bug) rather than an event to hide — dropping it would lose an image. That case is tracked separately for root-cause diagnosis.
+
 ## [0.16.0] - 2026-05-31
 
 ### Fixed

--- a/src/servers/DicomReceiver.test.ts
+++ b/src/servers/DicomReceiver.test.ts
@@ -916,6 +916,51 @@ describe('DicomReceiver', () => {
             await receiver.stop();
         });
 
+        it('suppresses a late ASSOCIATION_RECEIVED after the worker has finalized', async () => {
+            // Regression: dcmrecv stdout can deliver a stray ASSOCIATION_RECEIVED
+            // for a just-finished association after the worker finalized and went
+            // idle. Bubbling it would make a consumer register an association that
+            // never gets a matching ASSOCIATION_FINALIZED, stranding it.
+            const result = DicomReceiver.create({ port: 4242, storageDir: '/data', minPoolSize: 1, maxPoolSize: 1 });
+            if (!result.ok) return;
+
+            const receiver = result.value;
+            const events: PoolAssociationReceivedData[] = [];
+            receiver.onAssociationReceived(data => events.push(data));
+
+            await receiver.start();
+            const worker = createdFakes[0];
+            if (worker === undefined) return;
+
+            // Make worker busy, then a legitimate ASSOCIATION_RECEIVED bubbles.
+            if (connectionHandler !== undefined) {
+                connectionHandler(createMockSocket());
+                await delay(50);
+            }
+            worker.emit('ASSOCIATION_RECEIVED', { source: '192.168.1.1:5000', callingAE: 'SCU1', calledAE: 'DCMRECV' });
+            expect(events).toHaveLength(1);
+
+            // Finalize the association (worker → idle, finalized = true).
+            worker.emit('ASSOCIATION_COMPLETE', {
+                associationId: 'assoc-internal-1',
+                callingAE: 'SCU1',
+                calledAE: 'DCMRECV',
+                source: '192.168.1.1:5000',
+                files: [],
+                durationMs: 10,
+                endReason: 'release',
+            });
+            await delay(50);
+            expect(receiver.poolStatus.busy).toBe(0);
+
+            // A late stray ASSOCIATION_RECEIVED for the finished association must
+            // NOT bubble — still exactly one event from the legitimate one.
+            worker.emit('ASSOCIATION_RECEIVED', { source: '192.168.1.1:5000', callingAE: 'SCU1', calledAE: 'DCMRECV' });
+            expect(events).toHaveLength(1);
+
+            await receiver.stop();
+        });
+
         it('emits C_STORE_REQUEST when worker receives store request', async () => {
             const result = DicomReceiver.create({ port: 4242, storageDir: '/data', minPoolSize: 1, maxPoolSize: 1 });
             if (!result.ok) return;

--- a/src/servers/DicomReceiver.ts
+++ b/src/servers/DicomReceiver.ts
@@ -1369,6 +1369,15 @@ class DicomReceiver extends EventEmitter<DicomReceiverEventMap> {
     /** Bubbles ASSOCIATION_RECEIVED from dcmrecv worker. */
     private wireAssociationReceived(worker: Worker): void {
         worker.dcmrecv.onEvent('ASSOCIATION_RECEIVED', (data: { callingAE: string; calledAE: string; source: string }) => {
+            // Suppress a late/duplicate ASSOCIATION_RECEIVED that dcmrecv's
+            // stdout can deliver after the worker already finalized its
+            // association. Bubbling it would make a consumer register an
+            // association that never receives a matching ASSOCIATION_FINALIZED
+            // (the worker is done), stranding it until any consumer-side reaper
+            // fires. `finalized` is reset by beginAssociation before a genuinely
+            // new association's RECEIVED arrives, so only strays are filtered.
+            if (worker.finalized) return;
+
             // Record the hand-off so cleanup knows a consumer engaged with this
             // association (and therefore owns its directory cleanup).
             worker.markAssociationReceived();


### PR DESCRIPTION
## Summary
Follow-up to #27 (0.16.0). An end-to-end soak under extreme concurrency
(50 parallel single-file associations) surfaced a ~1/1500 residual: an
association left un-finalized from the consumer's view. Realistic batched
traffic was 100% clean; this only appears under pathological churn.

## Root cause
dcmrecv's stdout can deliver a stray `ASSOCIATION_RECEIVED` (or `FILE_RECEIVED`)
for an association *after* the worker has finalized it and gone idle. The pool
bubbled the late event, so a consumer registered an association that never got
a matching `ASSOCIATION_FINALIZED` — stranding it until a consumer-side reaper
fired. Distinct from the #27 double-assignment race (that was the primary
cause; this is the last residual).

## Fix
Suppress both events when `worker.finalized` is set. The flag stays true
between finalize and the next `beginAssociation` (which resets it before a
genuinely new association's events arrive), so only strays are filtered. The
#25 late-`FILE_RECEIVED`-during-finalizing path is unaffected — `finalized` is
set inside `finalizeAssociation`, after pending pipe chunks are processed.

## Validation
End-to-end (50-parallel single-file, 3000 associations, 300s consumer reaper):
| | 0.16.0 | this PR |
|---|---|---|
| final stranded associations | 1 (held 90s) | 0 |
| start = summary = complete | gap of 5 | exact (1636 each) |
| `FILE_RECEIVED with no active association` errors | 4 | 0 |

## Tests
New unit test (finalize a worker, assert a late `ASSOCIATION_RECEIVED` doesn't
bubble). Full suite: 2020/2020.

## Suggested release
Patch — `0.16.1`.