### PR TITLE
feat(tools): pure-JS dicom2json engine, deprecate dcm2json (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **`dicom2json` — pure-JS DICOM parsing, no DCMTK binaries required**
+  ([#30](https://github.com/MichaelLeeHobbs/dcmtk.js/issues/30)). A new parser built on
+  `dicom-parser` that produces the same DICOM JSON Model as `dcm2json`, ~75x faster
+  (measured 1.4ms vs 104ms per file): no process spawn, no multi-MB XML intermediate, and bulk
+  pixel data is never loaded. Character sets are decoded natively — all single-byte ISO_IR sets,
+  UTF-8, GB18030/GBK, Shift_JIS, and the common ISO 2022 code extensions (Japanese IR 13/87,
+  Korean IR 149, Chinese IR 58), validated against the PS3.5 Annex H/I/J examples. Also exports
+  a synchronous in-memory variant `dicom2jsonFromBuffer(buffer)`. Verified by a differential
+  integration suite: tag-for-tag agreement with the dcm2xml path across all 198 sample files.
+- **`DicomInstance.open` / `DicomReceiver` / `PacsClient` now parse with the JS engine by
+  default**, with automatic fallback to the DCMTK binaries when the JS parser fails
+  (`dcmtkFallback`). Pass `engine: 'dcmtk'` in `DicomOpenOptions` to force the old path.
+  This eliminates the timeout pathology from #30: the receiver's per-instance parse no longer
+  competes for CPU with dcm2xml's XML generation.
+- The JS engine includes file meta group 0002 in its output, so
+  `DicomDataset.transferSyntaxUID` now returns the actual transfer syntax (it was always
+  empty on the XML path, which omits group 0002).
+
+### Fixed
+
+- **`dcm2json`: fallback no longer runs with a doomed 1000ms floor**
+  ([#30](https://github.com/MichaelLeeHobbs/dcmtk.js/issues/30)). Previously, when the dcm2xml
+  path consumed the whole timeout budget, the direct-binary fallback ran with a hardcoded
+  `Math.max(1000, …)` floor, timed out immediately, and its error masked the real one. The
+  fallback now runs only with the genuinely remaining budget; when the budget is exhausted it
+  is skipped, and when both paths fail the returned error includes **both** failures.
+- **`xmlToJson`: empty value positions leaked their `number` attribute as the value.** An empty
+  `<Value number="1"/>` in dcm2xml output (e.g. ImageType `\SECONDARY\INTRAOPERATIVE`) was
+  decoded as the string `"1"` instead of `""`.
+
+### Deprecated
+
+- **`dcm2json` is deprecated in favor of `dicom2json`.** It remains exported and functional as
+  an escape hatch. Beyond performance, the binary path has a correctness defect the JS engine
+  does not: dcm2xml renumbers private tag blocks (e.g. `(0019,1030)` → `(0019,0030)`), which can
+  even overwrite the private-creator slot — verified against `dcmdump` ground truth.
+
+### Known limitations
+
+- The JS engine cannot tokenize files using **explicit VR** `SV`/`UV`/`OV` (rare, 2019-era VRs;
+  `dicom-parser` predates them). Such files fail gracefully and are covered by the automatic
+  DCMTK fallback in `DicomInstance.open`/`PacsClient`. Implicit VR files are unaffected.
+
 ## [1.0.0-rc.1] - 2026-07-11
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ All code **shall** comply with `docs/TypeScript Coding Standard for Mission-Crit
 
 51 async functions wrapping DCMTK binaries, organized by category:
 
-- **Data & Metadata** — `dcm2xml`, `dcm2json`, `dcmdump`, `dcmconv`, `dcmodify`, `dcmftest`, `dcmgpdir`, `dcmmkdir`, `dcmqridx`
+- **Data & Metadata** — `dcm2xml`, `dicom2json` (pure-JS, no binary), `dcm2json` (deprecated), `dcmdump`, `dcmconv`, `dcmodify`, `dcmftest`, `dcmgpdir`, `dcmmkdir`, `dcmqridx`
 - **File Conversion** — `xml2dcm`, `json2dcm`, `dump2dcm`, `img2dcm`, `pdf2dcm`, `dcm2pdf`, `cda2dcm`, `dcm2cda`, `stl2dcm`
 - **Compression** — `dcmcrle`, `dcmdrle`, `dcmencap`, `dcmdecap`, `dcmcjpeg`, `dcmdjpeg`, `dcmcjpls`, `dcmdjpls`
 - **Image Processing** — `dcmj2pnm`, `dcm2pnm`, `dcmscale`, `dcmquant`, `dcmdspfn`, `dcod2lum`, `dconvlum`
@@ -198,17 +198,18 @@ All tools: `(options) => Promise<Result<T>>`. All accept optional `signal: Abort
 
 #### Data & Metadata
 
-| Function   | Signature                                      | Description             |
-| ---------- | ---------------------------------------------- | ----------------------- |
-| `dcm2xml`  | `(inputPath, options?) => Result<{xml}>`       | DICOM to XML            |
-| `dcm2json` | `(inputPath, options?) => Result<{json}>`      | DICOM to JSON Model     |
-| `dcmdump`  | `(options) => Result<{output}>`                | Dump DICOM contents     |
-| `dcmconv`  | `(options) => Result<{outputPath}>`            | Convert transfer syntax |
-| `dcmodify` | `(inputPath, options) => Result<{outputPath}>` | Modify DICOM tags       |
-| `dcmftest` | `(options) => Result<{isValidDicom}>`          | Validate DICOM file     |
-| `dcmgpdir` | `(options) => Result<{}>`                      | Modify DICOMDIR         |
-| `dcmmkdir` | `(options) => Result<{}>`                      | Create DICOMDIR         |
-| `dcmqridx` | `(options) => Result<{}>`                      | Index DICOM database    |
+| Function     | Signature                                                   | Description                                                                                                                                                            |
+| ------------ | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dcm2xml`    | `(inputPath, options?) => Result<{xml}>`                    | DICOM to XML                                                                                                                                                           |
+| `dicom2json` | `(inputPath, options?) => Result<{data, warnings, source}>` | DICOM to JSON Model — pure JS, no DCMTK binary, ~75x faster; `dcmtkFallback` option retries via binaries. `dicom2jsonFromBuffer(buffer)` is the sync in-memory variant |
+| `dcm2json`   | `(inputPath, options?) => Result<{json}>`                   | **Deprecated** — DICOM to JSON Model via DCMTK binaries (renumbers private tag blocks; kept as escape hatch)                                                           |
+| `dcmdump`    | `(options) => Result<{output}>`                             | Dump DICOM contents                                                                                                                                                    |
+| `dcmconv`    | `(options) => Result<{outputPath}>`                         | Convert transfer syntax                                                                                                                                                |
+| `dcmodify`   | `(inputPath, options) => Result<{outputPath}>`              | Modify DICOM tags                                                                                                                                                      |
+| `dcmftest`   | `(options) => Result<{isValidDicom}>`                       | Validate DICOM file                                                                                                                                                    |
+| `dcmgpdir`   | `(options) => Result<{}>`                                   | Modify DICOMDIR                                                                                                                                                        |
+| `dcmmkdir`   | `(options) => Result<{}>`                                   | Create DICOMDIR                                                                                                                                                        |
+| `dcmqridx`   | `(options) => Result<{}>`                                   | Index DICOM database                                                                                                                                                   |
 
 #### File Conversion
 

--- a/docs/adr/006-pure-js-dicom-parsing.md
+++ b/docs/adr/006-pure-js-dicom-parsing.md
@@ -1,0 +1,58 @@
+# ADR 006: Pure-JS DICOM parsing (`dicom2json`)
+
+## Status
+
+Accepted (2026-07-22)
+
+## Context
+
+`dcm2json()` converted DICOM files to the DICOM JSON Model by spawning DCMTK binaries with a
+two-phase strategy: `dcm2xml` → XML → JSON (primary, for charset handling), falling back to the
+`dcm2json` binary (historically buggy — hangs on compressed pixel data). This produced a
+production incident ([#30](https://github.com/MichaelLeeHobbs/dcmtk.js/issues/30)): under CPU
+throttling, dcm2xml consumed the entire timeout budget (a 591KB dose SR emits 3.2MB of XML), the
+fallback ran with a hardcoded 1000ms floor, timed out, and its error masked the real cause.
+Instances were dropped after the C-STORE had been ACKed.
+
+Reordering the phases (dcm2json binary first) was rejected: the direct binary is the less
+trustworthy of the two. Instead, this ADR moves parsing into the process.
+
+## Decision
+
+Add `dicom2json`, a pure-JS parser, and make it the default engine for `DicomInstance.open`,
+`DicomReceiver` instance parsing, and `PacsClient` result parsing. Deprecate `dcm2json` but keep
+it exported, and use it as an automatic fallback (`dcmtkFallback: true`) from the high-level APIs.
+
+- **Tokenizer: `dicom-parser` 1.8.21** (Cornerstone/OHIF ecosystem; zero dependencies; proven in
+  production healthcare use). Rejected alternatives: `dcmjs` (its own long bug history plus heavy
+  naturalization we don't need), hand-rolled parser (largest effort and validation burden).
+- **Two layers of our own on top:**
+    - `_p10ToJson` — element walk → DICOM JSON Model (PS3.18 F.2), matching the shape the dcm2xml
+      path produced (PN component groups, numeric VR coercion, bare `{vr}` for bulk binary).
+      Sequence traversal is iterative (Rule 8.2). Implicit VR resolves through our 4,902-entry
+      dictionary via dicom-parser's `vrCallback`. Deflated transfer syntax inflates via `node:zlib`.
+    - `_charset` — SpecificCharacterSet decoding via Node's `TextDecoder`/`Buffer`: all single-byte
+      ISO_IR sets, UTF-8, GB18030/GBK, Shift_JIS, and ISO 2022 escape switching for the common CJK
+      cases (IR 13/87, IR 149, IR 58). Values are decoded before multi-value/PN splitting, which
+      sidesteps delimiter-byte collisions inside multi-byte encodings.
+
+## Verification
+
+- Differential integration suite: tag-for-tag agreement with the dcm2xml path across all 198
+  sample files (private tags and group 0002 excluded — see below). Performance gate: ≥5x faster
+  (measured ~75x: 1.4ms vs 104ms per file).
+- Charset fixtures validated against the DICOM PS3.5 Annex H/I/J examples.
+
+## Consequences
+
+- The #30 failure mode is structurally eliminated for the default path: no subprocess, no shared
+  CPU burn, no budget-splitting between phases. The legacy path's floor bug is fixed independently.
+- Two deliberate output differences, both verified against `dcmdump` ground truth:
+    - Group 0002 (file meta) is included → `DicomDataset.transferSyntaxUID` now works.
+    - Private tags keep their real block numbers. dcm2xml **renumbers private blocks** (e.g.
+      `(0019,1030)` → `(0019,0030)`), sometimes overwriting the private-creator slot — the old
+      output was lossy for private data.
+- Known limitation: explicit-VR `SV`/`UV`/`OV` files (rare) fail to tokenize in `dicom-parser`;
+  the automatic DCMTK fallback covers them. Implicit VR is unaffected.
+- `dicom-parser` is essentially finished software (slow release cadence). Acceptable: the format
+  is stable, the dependency is zero-deps, and the fallback path remains.

--- a/docs/tools/data-metadata.md
+++ b/docs/tools/data-metadata.md
@@ -30,9 +30,51 @@ if (result.ok) {
 
 ---
 
-## dcm2json
+## dicom2json
 
-Convert a DICOM file to DICOM JSON Model (PS3.18 F.2).
+Convert a DICOM file to DICOM JSON Model (PS3.18 F.2) **without DCMTK binaries** — a pure-JS parser
+(~75x faster than the dcm2xml path: no process spawn, no XML intermediate, bulk pixel data never loaded).
+
+```typescript
+import { dicom2json, dicom2jsonFromBuffer } from '@ubercode/dcmtk';
+
+const result = await dicom2json('/path/to/image.dcm');
+if (result.ok) {
+    console.log(result.value.data['00100010']); // Patient Name element
+    console.log('Source:', result.value.source); // 'js'
+}
+
+// Synchronous, in-memory variant (no file I/O):
+const bufferResult = dicom2jsonFromBuffer(buffer, { charsetAssume: 'latin-1' });
+```
+
+| Option            | Type      | Default | Description                                                                                     |
+| ----------------- | --------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `charsetAssume`   | `string`  | —       | Charset to assume when SpecificCharacterSet (0008,0005) is absent (`'ISO_IR 100'`, `'latin-1'`) |
+| `charsetFallback` | `string`  | —       | Charset to decode with when the file's charset is unsupported (`'latin-1'` recommended)         |
+| `dcmtkFallback`   | `boolean` | `false` | Retry with the deprecated dcm2json binary path when the JS parser fails                         |
+
+**Result:** `{ data: DicomJsonModel, warnings: readonly string[], source: 'js' | 'xml' | 'direct' }`
+
+Character sets: all single-byte ISO_IR sets, UTF-8, GB18030/GBK, Shift_JIS, and the common
+ISO 2022 code extensions (Japanese IR 13/87, Korean IR 149, Chinese IR 58) are decoded natively.
+
+Differences from the dcm2json binary path (both verified against `dcmdump` ground truth):
+
+- File meta group 0002 elements are **included**, so `DicomDataset.transferSyntaxUID` works.
+- Private tags keep their real block numbers (dcm2xml renumbers private blocks incorrectly).
+- Known limitation: files using **explicit VR** `SV`/`UV`/`OV` (rare, 2019-era VRs) fail to
+  tokenize — enable `dcmtkFallback` to cover them. Implicit VR files are unaffected.
+
+---
+
+## dcm2json (deprecated)
+
+> **Deprecated:** use [`dicom2json`](#dicom2json). This path spawns DCMTK binaries, is ~75x slower,
+> and renumbers private tag blocks in its XML output. It remains available as an escape hatch
+> (see `dcmtkFallback` above).
+
+Convert a DICOM file to DICOM JSON Model (PS3.18 F.2) using DCMTK binaries.
 
 ```typescript
 import { dcm2json } from '@ubercode/dcmtk';
@@ -50,7 +92,9 @@ if (result.ok) {
 
 **Result:** `{ data: DicomJsonModel, source: 'xml' | 'direct' }`
 
-Internally uses a two-phase strategy: dcm2xml then XML parsing (more reliable), with direct dcm2json as fallback.
+Internally uses a two-phase strategy: dcm2xml then XML parsing (more reliable), with direct dcm2json
+as fallback. The fallback only runs when time budget remains; when both paths fail, the error
+includes both failures.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
         ]
     },
     "dependencies": {
+        "dicom-parser": "1.8.21",
         "fast-xml-parser": "5.8.0",
         "stderr-lib": "2.2.0",
         "tree-kill": "1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      dicom-parser:
+        specifier: 1.8.21
+        version: 1.8.21
       fast-xml-parser:
         specifier: 5.8.0
         version: 5.8.0
@@ -689,6 +692,9 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  dicom-parser@1.8.21:
+    resolution: {integrity: sha512-lYCweHQDsC8UFpXErPlg86Px2A8bay0HiUY+wzoG3xv5GzgqVHU3lziwSc/Gzn7VV7y2KeP072SzCviuOoU02w==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1902,6 +1908,8 @@ snapshots:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
+
+  dicom-parser@1.8.21: {}
 
   emoji-regex@10.6.0: {}
 

--- a/src/dicom/DicomInstance.test.ts
+++ b/src/dicom/DicomInstance.test.ts
@@ -11,6 +11,10 @@ vi.mock('../tools/dcm2json', () => ({
     dcm2json: vi.fn(),
 }));
 
+vi.mock('../tools/dicom2json', () => ({
+    dicom2json: vi.fn(),
+}));
+
 vi.mock('../tools/dcmodify', () => ({
     dcmodify: vi.fn(),
 }));
@@ -22,10 +26,12 @@ vi.mock('node:fs/promises', () => ({
 }));
 
 import { dcm2json } from '../tools/dcm2json';
+import { dicom2json } from '../tools/dicom2json';
 import { dcmodify } from '../tools/dcmodify';
 import { copyFile, stat, unlink } from 'node:fs/promises';
 
 const mockedDcm2json = vi.mocked(dcm2json);
+const mockedDicom2json = vi.mocked(dicom2json);
 const mockedDcmodify = vi.mocked(dcmodify);
 const mockedCopyFile = vi.mocked(copyFile);
 const mockedStat = vi.mocked(stat);
@@ -45,6 +51,10 @@ beforeEach(() => {
     mockedDcm2json.mockResolvedValue({
         ok: true,
         value: { data: SAMPLE_JSON, source: 'xml' as const },
+    });
+    mockedDicom2json.mockResolvedValue({
+        ok: true,
+        value: { data: SAMPLE_JSON, warnings: [], source: 'js' as const },
     });
     mockedDcmodify.mockResolvedValue({
         ok: true,
@@ -72,47 +82,61 @@ describe('DicomInstance', () => {
             expect(result.ok).toBe(false);
         });
 
-        it('returns error when dcm2json fails', async () => {
-            mockedDcm2json.mockResolvedValue({
+        it('returns error when the parser fails', async () => {
+            mockedDicom2json.mockResolvedValue({
                 ok: false,
-                error: new Error('dcm2json: failed'),
+                error: new Error('dicom2json: failed'),
             });
             const result = await DicomInstance.open('/path/to/test.dcm');
             expect(result.ok).toBe(false);
         });
 
         it('returns error for invalid JSON data', async () => {
-            mockedDcm2json.mockResolvedValue({
+            mockedDicom2json.mockResolvedValue({
                 ok: true,
-                value: { data: null as unknown as DicomJsonModel, source: 'xml' as const },
+                value: { data: null as unknown as DicomJsonModel, warnings: [], source: 'js' as const },
             });
             const result = await DicomInstance.open('/path/to/test.dcm');
             expect(result.ok).toBe(false);
         });
 
-        it('passes options to dcm2json', async () => {
+        it('passes options to dicom2json with DCMTK fallback enabled', async () => {
             const controller = new AbortController();
             await DicomInstance.open('/path/to/test.dcm', {
                 timeoutMs: 5000,
                 signal: controller.signal,
             });
-            expect(mockedDcm2json).toHaveBeenCalledWith('/path/to/test.dcm', {
+            expect(mockedDicom2json).toHaveBeenCalledWith('/path/to/test.dcm', {
                 timeoutMs: 5000,
                 signal: controller.signal,
                 charsetAssume: undefined,
+                dcmtkFallback: true,
             });
+            expect(mockedDcm2json).not.toHaveBeenCalled();
         });
 
-        it('passes charsetAssume to dcm2json', async () => {
+        it('passes charsetAssume to dicom2json', async () => {
             await DicomInstance.open('/path/to/test.dcm', {
                 charsetAssume: 'ISO_IR 100',
             });
-            expect(mockedDcm2json).toHaveBeenCalledWith(
+            expect(mockedDicom2json).toHaveBeenCalledWith(
                 '/path/to/test.dcm',
                 expect.objectContaining({
                     charsetAssume: 'ISO_IR 100',
                 })
             );
+        });
+
+        it("uses the deprecated dcm2json path when engine is 'dcmtk'", async () => {
+            const result = await DicomInstance.open('/path/to/test.dcm', { engine: 'dcmtk' });
+            expect(result.ok).toBe(true);
+            expect(mockedDcm2json).toHaveBeenCalledWith(
+                '/path/to/test.dcm',
+                expect.objectContaining({
+                    timeoutMs: expect.any(Number) as number,
+                })
+            );
+            expect(mockedDicom2json).not.toHaveBeenCalled();
         });
     });
 

--- a/src/dicom/DicomInstance.ts
+++ b/src/dicom/DicomInstance.ts
@@ -15,9 +15,27 @@ import type { Result } from '../types';
 import { err, ok } from '../types';
 import { ChangeSet } from './ChangeSet';
 import { DicomDataset } from './DicomDataset';
-import { dcm2json } from '../tools';
+import { dcm2json, dicom2json } from '../tools';
+import type { DicomJsonModel } from '../tools';
 import type { DicomOpenOptions, FileIOOptions } from './_fileHelpers';
 import { applyModifications, copyFileSafe, statFileSize, unlinkFile } from './_fileHelpers';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Reads a DICOM file into the JSON Model using the engine selected in the options. */
+async function readDicomJson(path: string, options?: DicomOpenOptions): Promise<Result<DicomJsonModel>> {
+    const shared = {
+        timeoutMs: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+        signal: options?.signal,
+        charsetAssume: options?.charsetAssume,
+        charsetFallback: options?.charsetFallback,
+    };
+    const result = options?.engine === 'dcmtk' ? await dcm2json(path, shared) : await dicom2json(path, { ...shared, dcmtkFallback: true });
+    if (!result.ok) return err(result.error);
+    return ok(result.value.data);
+}
 
 // ---------------------------------------------------------------------------
 // DicomInstance class
@@ -69,15 +87,10 @@ class DicomInstance {
         const filePathResult = createDicomFilePath(path);
         if (!filePathResult.ok) return err(filePathResult.error);
 
-        const jsonResult = await dcm2json(path, {
-            timeoutMs: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
-            signal: options?.signal,
-            charsetAssume: options?.charsetAssume,
-            charsetFallback: options?.charsetFallback,
-        });
+        const jsonResult = await readDicomJson(path, options);
         if (!jsonResult.ok) return err(jsonResult.error);
 
-        const datasetResult = DicomDataset.fromJson(jsonResult.value.data);
+        const datasetResult = DicomDataset.fromJson(jsonResult.value);
         if (!datasetResult.ok) return err(datasetResult.error);
 
         return ok(new DicomInstance(datasetResult.value, ChangeSet.empty(), filePathResult.value, new Map()));

--- a/src/dicom/_fileHelpers.ts
+++ b/src/dicom/_fileHelpers.ts
@@ -25,10 +25,16 @@ interface FileIOOptions {
 
 /** Options for opening a DICOM file. Extends FileIOOptions with read-specific settings. */
 interface DicomOpenOptions extends FileIOOptions {
-    /** Assume the specified character set when SpecificCharacterSet (0008,0005) is absent. Maps to dcm2xml `+Ca`. */
+    /** Assume the specified character set when SpecificCharacterSet (0008,0005) is absent. Accepts DICOM defined terms ('ISO_IR 100') or DCMTK-style aliases ('latin-1'). */
     readonly charsetAssume?: string | undefined;
-    /** Fallback charset to retry with when UTF-8 conversion fails due to illegal byte sequences. Maps to dcm2xml `+Ca`. When set, a charset conversion failure triggers an automatic retry with this charset assumed. `'Latin1'` is recommended — it maps every byte 0x00-0xFF to a valid character, so conversion never fails. */
+    /** Fallback charset to decode with when the file's character set is unsupported or conversion fails. `'latin-1'` is recommended — it maps every byte 0x00-0xFF to a valid character, so decoding never fails. */
     readonly charsetFallback?: string | undefined;
+    /**
+     * Parse engine. `'js'` (default) parses in-process via {@link dicom2json}
+     * and automatically falls back to the DCMTK binaries when the JS parser
+     * fails; `'dcmtk'` uses the deprecated dcm2json binary path exclusively.
+     */
+    readonly engine?: 'js' | 'dcmtk' | undefined;
 }
 
 /** Bridges a ChangeSet to a dcmodify call on the given file. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,9 @@ export type { Dcm2xmlOptions, Dcm2xmlResult, Dcm2xmlCharsetValue } from './tools
 export { dcm2json } from './tools/dcm2json';
 export type { Dcm2jsonOptions, Dcm2jsonResult, Dcm2jsonSource, DicomJsonModel } from './tools/dcm2json';
 
+export { dicom2json, dicom2jsonFromBuffer } from './tools/dicom2json';
+export type { Dicom2jsonOptions, Dicom2jsonBufferOptions, Dicom2jsonResult, Dicom2jsonSource } from './tools/dicom2json';
+
 export { dcmdump, DcmdumpFormat } from './tools/dcmdump';
 export type { DcmdumpOptions, DcmdumpResult, DcmdumpFormatValue } from './tools/dcmdump';
 

--- a/src/pacs/parseResults.test.ts
+++ b/src/pacs/parseResults.test.ts
@@ -8,18 +8,18 @@ vi.mock('node:fs/promises', () => ({
     rm: vi.fn(),
 }));
 
-vi.mock('../tools/dcm2json', () => ({
-    dcm2json: vi.fn(),
+vi.mock('../tools/dicom2json', () => ({
+    dicom2json: vi.fn(),
 }));
 
 import { mkdtemp, readdir, rm } from 'node:fs/promises';
-import { dcm2json } from '../tools/dcm2json';
+import { dicom2json } from '../tools/dicom2json';
 import { createTempDir, listDcmFiles, cleanupTempDir, parseSingleFile, parseExtractedFiles, MAX_RESPONSE_FILES } from './parseResults';
 
 const mockedMkdtemp = vi.mocked(mkdtemp);
 const mockedReaddir = vi.mocked(readdir);
 const mockedRm = vi.mocked(rm);
-const mockedDcm2json = vi.mocked(dcm2json);
+const mockedDcm2json = vi.mocked(dicom2json);
 
 beforeEach(() => {
     vi.clearAllMocks();
@@ -113,7 +113,7 @@ describe('cleanupTempDir', () => {
 describe('parseSingleFile', () => {
     it('parses a DICOM file into a DicomDataset', async () => {
         const mockJson = { '00100010': { vr: 'PN', Value: [{ Alphabetic: 'DOE^JOHN' }] } };
-        mockedDcm2json.mockResolvedValue(ok({ data: mockJson, source: 'xml' as const }));
+        mockedDcm2json.mockResolvedValue(ok({ data: mockJson, warnings: [], source: 'js' as const }));
         const result = await parseSingleFile('/tmp/test.dcm', 30000);
         expect(result.ok).toBe(true);
         if (result.ok) {
@@ -127,14 +127,15 @@ describe('parseSingleFile', () => {
         expect(result.ok).toBe(false);
     });
 
-    it('passes timeout and signal to dcm2json', async () => {
+    it('passes timeout, signal, and DCMTK fallback to dicom2json', async () => {
         const controller = new AbortController();
         const mockJson = { '00100010': { vr: 'PN', Value: [{ Alphabetic: 'TEST' }] } };
-        mockedDcm2json.mockResolvedValue(ok({ data: mockJson, source: 'xml' as const }));
+        mockedDcm2json.mockResolvedValue(ok({ data: mockJson, warnings: [], source: 'js' as const }));
         await parseSingleFile('/tmp/test.dcm', 5000, controller.signal);
         expect(mockedDcm2json).toHaveBeenCalledWith('/tmp/test.dcm', {
             timeoutMs: 5000,
             signal: controller.signal,
+            dcmtkFallback: true,
         });
     });
 });
@@ -143,7 +144,7 @@ describe('parseExtractedFiles', () => {
     it('parses all dcm files in the directory', async () => {
         mockedReaddir.mockResolvedValue(['a.dcm', 'b.dcm'] as never);
         const mockJson = { '00100010': { vr: 'PN', Value: [{ Alphabetic: 'TEST' }] } };
-        mockedDcm2json.mockResolvedValue(ok({ data: mockJson, source: 'xml' as const }));
+        mockedDcm2json.mockResolvedValue(ok({ data: mockJson, warnings: [], source: 'js' as const }));
 
         const result = await parseExtractedFiles('/tmp/test', 30000, 5);
         expect(result.ok).toBe(true);
@@ -164,7 +165,7 @@ describe('parseExtractedFiles', () => {
     it('skips files that fail to parse', async () => {
         mockedReaddir.mockResolvedValue(['good.dcm', 'bad.dcm'] as never);
         const mockJson = { '00100010': { vr: 'PN', Value: [{ Alphabetic: 'TEST' }] } };
-        mockedDcm2json.mockResolvedValueOnce(ok({ data: mockJson, source: 'xml' as const })).mockResolvedValueOnce(err(new Error('corrupt file')));
+        mockedDcm2json.mockResolvedValueOnce(ok({ data: mockJson, warnings: [], source: 'js' as const })).mockResolvedValueOnce(err(new Error('corrupt file')));
 
         const result = await parseExtractedFiles('/tmp/test', 30000, 5);
         expect(result.ok).toBe(true);
@@ -186,7 +187,7 @@ describe('parseExtractedFiles', () => {
         }
         mockedReaddir.mockResolvedValue(entries as never);
         const mockJson = { '00100010': { vr: 'PN', Value: [{ Alphabetic: 'TEST' }] } };
-        mockedDcm2json.mockResolvedValue(ok({ data: mockJson, source: 'xml' as const }));
+        mockedDcm2json.mockResolvedValue(ok({ data: mockJson, warnings: [], source: 'js' as const }));
 
         const result = await parseExtractedFiles('/tmp/test', 30000, 2);
         expect(result.ok).toBe(true);
@@ -206,7 +207,7 @@ describe('parseExtractedFiles', () => {
         controller.abort();
 
         const mockJson = { '00100010': { vr: 'PN', Value: [{ Alphabetic: 'TEST' }] } };
-        mockedDcm2json.mockResolvedValue(ok({ data: mockJson, source: 'xml' as const }));
+        mockedDcm2json.mockResolvedValue(ok({ data: mockJson, warnings: [], source: 'js' as const }));
 
         const result = await parseExtractedFiles('/tmp/test', 30000, 2, controller.signal);
         expect(result.ok).toBe(true);

--- a/src/pacs/parseResults.ts
+++ b/src/pacs/parseResults.ts
@@ -2,7 +2,7 @@
  * Parses extracted DICOM response files from findscu --extract.
  *
  * Creates temp directories, lists .dcm files, and batch-parses them
- * into DicomDataset instances using dcm2json.
+ * into DicomDataset instances using dicom2json (pure-JS, DCMTK fallback).
  *
  * @module pacs/parseResults
  */
@@ -14,7 +14,7 @@ import { stderr, tryCatch } from 'stderr-lib';
 
 import type { Result } from '../types';
 import { ok, err } from '../types';
-import { dcm2json } from '../tools/dcm2json';
+import { dicom2json } from '../tools/dicom2json';
 import { DicomDataset } from '../dicom/DicomDataset';
 
 /** Maximum number of response files to process (safety bound per Rule 8.1). */
@@ -79,12 +79,12 @@ async function cleanupTempDir(directory: string): Promise<void> {
  * Parses a single DICOM file into a DicomDataset.
  *
  * @param filePath - Path to the .dcm file
- * @param timeoutMs - Timeout for dcm2json
+ * @param timeoutMs - Timeout per parse
  * @param signal - Optional abort signal
  * @returns A Result containing the DicomDataset
  */
 async function parseSingleFile(filePath: string, timeoutMs: number, signal?: AbortSignal): Promise<Result<DicomDataset>> {
-    const jsonResult = await dcm2json(filePath, { timeoutMs, signal });
+    const jsonResult = await dicom2json(filePath, { timeoutMs, signal, dcmtkFallback: true });
     if (!jsonResult.ok) {
         return err(jsonResult.error);
     }
@@ -100,7 +100,7 @@ async function parseSingleFile(filePath: string, timeoutMs: number, signal?: Abo
  * detect partial failures.
  *
  * @param directory - Directory containing extracted .dcm files
- * @param timeoutMs - Timeout per file for dcm2json
+ * @param timeoutMs - Timeout per file
  * @param concurrency - Max concurrent parse operations
  * @param signal - Optional abort signal
  * @returns A Result containing the array of DicomDatasets

--- a/src/tools/_charset.test.ts
+++ b/src/tools/_charset.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCharsetContext, decodeDicomText, normalizeCharsetName, DEFAULT_CONTEXT } from './_charset';
+import type { CharsetContext } from './_charset';
+
+/** Resolves a context or fails the test. */
+function ctx(specific: string | undefined, assume?: string, fallback?: string): CharsetContext {
+    const result = resolveCharsetContext(specific, assume, fallback);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw result.error;
+    return result.value;
+}
+
+/** Decodes a latin1-notated byte string under the given SpecificCharacterSet. */
+function decode(specific: string | undefined, byteString: string): string {
+    return decodeDicomText(Buffer.from(byteString, 'latin1'), ctx(specific));
+}
+
+describe('resolveCharsetContext', () => {
+    it('returns the default (ASCII) context when 0008,0005 is absent', () => {
+        const result = resolveCharsetContext(undefined);
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.value).toBe(DEFAULT_CONTEXT);
+    });
+
+    it('treats an empty/blank 0008,0005 as the default repertoire', () => {
+        expect(ctx('').iso2022).toBe(false);
+        expect(ctx('  ').terms).toEqual(['ISO_IR 6']);
+    });
+
+    it('resolves single-byte charsets', () => {
+        expect(ctx('ISO_IR 100').iso2022).toBe(false);
+        expect(ctx('ISO_IR 192').terms).toEqual(['ISO_IR 192']);
+    });
+
+    it('marks multi-valued and ISO 2022 charsets as iso2022', () => {
+        expect(ctx('ISO 2022 IR 6\\ISO 2022 IR 87').iso2022).toBe(true);
+        expect(ctx('ISO 2022 IR 149').iso2022).toBe(true);
+    });
+
+    it('maps an empty first value to the default repertoire term', () => {
+        expect(ctx('\\ISO 2022 IR 149').terms[0]).toBe('ISO 2022 IR 6');
+    });
+
+    it('applies charsetAssume only when 0008,0005 is absent', () => {
+        expect(ctx(undefined, 'latin-1').terms).toEqual(['ISO_IR 100']);
+        expect(ctx('ISO_IR 144', 'latin-1').terms).toEqual(['ISO_IR 144']);
+    });
+
+    it('accepts DICOM defined terms and aliases for charsetAssume', () => {
+        expect(ctx(undefined, 'ISO_IR 144').terms).toEqual(['ISO_IR 144']);
+        expect(ctx(undefined, 'utf-8').terms).toEqual(['ISO_IR 192']);
+    });
+
+    it('errors on an unsupported charset without a fallback', () => {
+        const result = resolveCharsetContext('ISO_IR 999');
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error.message).toContain('ISO_IR 999');
+    });
+
+    it('uses the fallback for an unsupported charset', () => {
+        expect(ctx('ISO_IR 999', undefined, 'latin-1').terms).toEqual(['ISO_IR 100']);
+    });
+
+    it('errors on an unsupported charsetAssume without a fallback', () => {
+        const result = resolveCharsetContext(undefined, 'klingon');
+        expect(result.ok).toBe(false);
+    });
+
+    it('falls back when charsetAssume is unsupported', () => {
+        expect(ctx(undefined, 'klingon', 'latin-1').terms).toEqual(['ISO_IR 100']);
+    });
+
+    it('errors when the fallback itself is unsupported', () => {
+        const result = resolveCharsetContext('ISO_IR 999', undefined, 'also-bad');
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error.message).toContain('also-bad');
+    });
+});
+
+describe('normalizeCharsetName', () => {
+    it('passes through defined terms', () => {
+        expect(normalizeCharsetName('ISO_IR 100')).toBe('ISO_IR 100');
+        expect(normalizeCharsetName('ISO 2022 IR 87')).toBe('ISO 2022 IR 87');
+        expect(normalizeCharsetName('GB18030')).toBe('GB18030');
+    });
+
+    it('maps DCMTK-style aliases case-insensitively', () => {
+        expect(normalizeCharsetName('Latin-1')).toBe('ISO_IR 100');
+        expect(normalizeCharsetName('UTF-8')).toBe('ISO_IR 192');
+        expect(normalizeCharsetName('cyrillic')).toBe('ISO_IR 144');
+        expect(normalizeCharsetName('shift_jis')).toBe('ISO_IR 13');
+    });
+
+    it('returns undefined for unknown names', () => {
+        expect(normalizeCharsetName('klingon')).toBeUndefined();
+    });
+});
+
+describe('decodeDicomText — single-byte charsets', () => {
+    it('decodes ASCII / default repertoire', () => {
+        expect(decode(undefined, 'Smith^John')).toBe('Smith^John');
+    });
+
+    it('decodes ISO_IR 100 (Latin-1)', () => {
+        expect(decode('ISO_IR 100', 'M\xfcller^J\xf6rg')).toBe('Müller^Jörg');
+    });
+
+    it('decodes ISO_IR 144 (Cyrillic)', () => {
+        expect(decode('ISO_IR 144', '\xbb\xee\xda\xe1\xd5\xdc\xd1\xe3\xe0\xd3')).toBe('Люксембург');
+    });
+
+    it('decodes ISO_IR 126 (Greek)', () => {
+        expect(decode('ISO_IR 126', '\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2')).toBe('Διονυσιος');
+    });
+
+    it('decodes ISO_IR 127 (Arabic)', () => {
+        expect(decode('ISO_IR 127', '\xe2\xc8\xc7\xe6\xea')).toBe('قباني');
+    });
+
+    it('decodes ISO_IR 138 (Hebrew)', () => {
+        expect(decode('ISO_IR 138', '\xf9\xf8\xe5\xef^\xe3\xe1\xe5\xf8\xe4')).toBe('שרון^דבורה');
+    });
+
+    it('decodes ISO_IR 166 (Thai)', () => {
+        expect(decode('ISO_IR 166', '\xb9\xc7\xd1\xb2\xb9\xec')).toBe('นวัฒน์');
+    });
+
+    it('decodes ISO_IR 192 (UTF-8)', () => {
+        const bytes = Buffer.from('Wang^XiaoDong=王^小东', 'utf8').toString('latin1');
+        expect(decode('ISO_IR 192', bytes)).toBe('Wang^XiaoDong=王^小东');
+    });
+
+    it('decodes GB18030', () => {
+        expect(decode('GB18030', 'Wang^XiaoDong=\xcd\xf5^\xd0\xa1\xb6\xab=')).toBe('Wang^XiaoDong=王^小东=');
+    });
+
+    it('decodes ISO_IR 13 (Shift_JIS katakana)', () => {
+        expect(decode('ISO_IR 13', '\xd4\xcf\xc0\xde^\xc0\xdb\xb3')).toBe('ﾔﾏﾀﾞ^ﾀﾛｳ');
+    });
+
+    it('returns empty string for empty input', () => {
+        expect(decode('ISO_IR 100', '')).toBe('');
+    });
+});
+
+describe('decodeDicomText — ISO 2022 code extensions', () => {
+    it('decodes the PS3.5 H.3 Japanese example (ISO 2022 IR 87)', () => {
+        const bytes = 'Yamada^Tarou=\x1b$B;3ED\x1b(B^\x1b$BB@O:\x1b(B=\x1b$B$d$^$@\x1b(B^\x1b$B$?$m$&\x1b(B';
+        expect(decode('ISO 2022 IR 6\\ISO 2022 IR 87', bytes)).toBe('Yamada^Tarou=山田^太郎=やまだ^たろう');
+    });
+
+    it('decodes the PS3.5 H.2 Japanese example (ISO 2022 IR 13 + 87)', () => {
+        const bytes = '\xd4\xcf\xc0\xde^\xc0\xdb\xb3=\x1b$B;3ED\x1b(J^\x1b$BB@O:\x1b(J=\x1b$B$d$^$@\x1b(J^\x1b$B$?$m$&\x1b(J';
+        expect(decode('ISO 2022 IR 13\\ISO 2022 IR 87', bytes)).toBe('ﾔﾏﾀﾞ^ﾀﾛｳ=山田^太郎=やまだ^たろう');
+    });
+
+    it('decodes the PS3.5 I.2 Korean example (ISO 2022 IR 149)', () => {
+        const bytes = 'Hong^Gildong=\x1b$)C\xfb\xf3^\x1b$)C\xd1\xce\xd4\xd7=\x1b$)C\xc8\xab^\x1b$)C\xb1\xe6\xb5\xbf';
+        expect(decode('\\ISO 2022 IR 149', bytes)).toBe('Hong^Gildong=洪^吉洞=홍^길동');
+    });
+
+    it('decodes the Chinese ISO 2022 IR 58 example', () => {
+        const bytes = 'Zhang^XiaoDong=\x1b$)A\xd5\xc5^\x1b$)A\xd0\xa1\xb6\xab=';
+        expect(decode('\\ISO 2022 IR 58', bytes)).toBe('Zhang^XiaoDong=张^小东=');
+    });
+
+    it('decodes G1 single-byte designations (ESC - L → ISO-8859-5)', () => {
+        expect(decode('ISO 2022 IR 6\\ISO 2022 IR 144', 'abc\x1b-L\xbb\xee\xda')).toBe('abcЛюк');
+    });
+
+    it('keeps the current decoder on unrecognized escape sequences', () => {
+        expect(decode('ISO 2022 IR 6\\ISO 2022 IR 87', 'abc\x1b%Gdef')).toBe('abcdef');
+    });
+
+    it('handles a truncated escape sequence at end of input', () => {
+        expect(decode('ISO 2022 IR 6\\ISO 2022 IR 87', 'abc\x1b')).toBe('abc');
+        expect(decode('ISO 2022 IR 6\\ISO 2022 IR 87', 'abc\x1b$')).toBe('abc');
+    });
+
+    it('decodes an ISO 2022 IR 100 initial designation without escapes', () => {
+        expect(decode('ISO 2022 IR 100', 'M\xfcller')).toBe('Müller');
+    });
+});

--- a/src/tools/_charset.ts
+++ b/src/tools/_charset.ts
@@ -1,0 +1,335 @@
+/**
+ * DICOM character set decoding for the pure-JS parser.
+ *
+ * Maps SpecificCharacterSet (0008,0005) defined terms to JavaScript decoders
+ * and decodes raw element bytes into JS strings, including ISO 2022 code
+ * extensions (escape-sequence switching) for the common CJK cases:
+ * Japanese (ISO 2022 IR 13/87), Korean (ISO 2022 IR 149), and
+ * Chinese (ISO 2022 IR 58).
+ *
+ * Values are decoded to full strings first; multi-value and person-name
+ * splitting happens on the decoded string, which avoids delimiter-byte
+ * collisions inside multi-byte encodings (e.g. 0x5C as a trailing byte
+ * in GBK/Shift_JIS/JIS X 0208 sequences).
+ *
+ * @module _charset
+ * @internal
+ */
+
+import type { Result } from '../types';
+import { ok, err } from '../types';
+
+/** How to decode a run of bytes. */
+type SegmentDecoder =
+    /** ISO-8859-1: every byte maps to U+00xx. Also used for ASCII. */
+    | { readonly kind: 'latin1' }
+    /** A WHATWG TextDecoder label (e.g. 'iso-8859-5', 'utf-8', 'euc-kr'). */
+    | { readonly kind: 'label'; readonly label: string }
+    /** JIS X 0208 two-byte GL codes: re-wrapped with its ISO 2022 escape and decoded as iso-2022-jp. */
+    | { readonly kind: 'iso2022jp'; readonly escape: readonly number[] }
+    /** JIS X 0201 katakana (GR single-byte, 0xA1-0xDF): decoded as shift_jis. */
+    | { readonly kind: 'katakana' };
+
+const LATIN1: SegmentDecoder = { kind: 'latin1' };
+
+/** Builds a label decoder. */
+function label(name: string): SegmentDecoder {
+    return { kind: 'label', label: name };
+}
+
+/**
+ * Single-byte and non-extension charsets: DICOM defined term → decoder.
+ * WHATWG maps some ISO labels to their Windows supersets (e.g. iso-8859-9 →
+ * windows-1254); the differences are confined to the C1 control range
+ * 0x80-0x9F, which DICOM text does not use.
+ */
+const CHARSET_DECODERS: Readonly<Record<string, SegmentDecoder>> = {
+    'ISO_IR 6': LATIN1,
+    'ISO_IR 100': LATIN1,
+    'ISO_IR 101': label('iso-8859-2'),
+    'ISO_IR 109': label('iso-8859-3'),
+    'ISO_IR 110': label('iso-8859-4'),
+    'ISO_IR 144': label('iso-8859-5'),
+    'ISO_IR 127': label('iso-8859-6'),
+    'ISO_IR 126': label('iso-8859-7'),
+    'ISO_IR 138': label('iso-8859-8'),
+    'ISO_IR 148': label('iso-8859-9'),
+    'ISO_IR 203': label('iso-8859-15'),
+    'ISO_IR 13': label('shift_jis'),
+    'ISO_IR 166': label('windows-874'),
+    'ISO_IR 192': label('utf-8'),
+    GB18030: label('gb18030'),
+    GBK: label('gbk'),
+};
+
+/**
+ * Initial decoder for ISO 2022 charsets (before any escape sequence).
+ * Terms designating multi-byte G0 sets (IR 87/159) start in ASCII — the
+ * multi-byte set is only active after its escape sequence.
+ */
+const ISO2022_INITIAL: Readonly<Record<string, SegmentDecoder>> = {
+    'ISO 2022 IR 6': LATIN1,
+    'ISO 2022 IR 13': label('shift_jis'),
+    'ISO 2022 IR 87': LATIN1,
+    'ISO 2022 IR 159': LATIN1,
+    'ISO 2022 IR 149': label('euc-kr'),
+    'ISO 2022 IR 58': label('gbk'),
+    'ISO 2022 IR 100': LATIN1,
+    'ISO 2022 IR 101': label('iso-8859-2'),
+    'ISO 2022 IR 109': label('iso-8859-3'),
+    'ISO 2022 IR 110': label('iso-8859-4'),
+    'ISO 2022 IR 144': label('iso-8859-5'),
+    'ISO 2022 IR 127': label('iso-8859-6'),
+    'ISO 2022 IR 126': label('iso-8859-7'),
+    'ISO 2022 IR 138': label('iso-8859-8'),
+    'ISO 2022 IR 148': label('iso-8859-9'),
+    'ISO 2022 IR 166': label('windows-874'),
+    'ISO 2022 IR 203': label('iso-8859-15'),
+};
+
+/**
+ * ISO 2022 escape sequences (bytes after ESC, as a string key) → decoder
+ * for the following run. Per DICOM PS3.5 Table 6.3-1.
+ */
+const ESCAPE_DECODERS: Readonly<Record<string, SegmentDecoder>> = {
+    '(B': LATIN1, // G0 = ASCII
+    '(J': LATIN1, // G0 = JIS X 0201 romaji
+    ')I': { kind: 'katakana' }, // G1 = JIS X 0201 katakana
+    '$@': { kind: 'iso2022jp', escape: [0x1b, 0x24, 0x40] }, // G0 = JIS X 0208-1978
+    $B: { kind: 'iso2022jp', escape: [0x1b, 0x24, 0x42] }, // G0 = JIS X 0208
+    '$(D': { kind: 'iso2022jp', escape: [0x1b, 0x24, 0x28, 0x44] }, // G0 = JIS X 0212
+    '$)C': label('euc-kr'), // G1 = KS X 1001
+    '$)A': label('gbk'), // G1 = GB 2312
+    '-A': LATIN1, // G1 = ISO-8859-1
+    '-B': label('iso-8859-2'),
+    '-C': label('iso-8859-3'),
+    '-D': label('iso-8859-4'),
+    '-F': label('iso-8859-7'),
+    '-G': label('iso-8859-6'),
+    '-H': label('iso-8859-8'),
+    '-L': label('iso-8859-5'),
+    '-M': label('iso-8859-9'),
+    '-T': label('windows-874'),
+    '-b': label('iso-8859-15'),
+};
+
+/** Aliases accepted for charsetAssume/charsetFallback (lowercased) → DICOM defined term. */
+const CHARSET_ALIASES: Readonly<Record<string, string>> = {
+    ascii: 'ISO_IR 6',
+    'latin-1': 'ISO_IR 100',
+    latin1: 'ISO_IR 100',
+    'iso-8859-1': 'ISO_IR 100',
+    'latin-2': 'ISO_IR 101',
+    'latin-3': 'ISO_IR 109',
+    'latin-4': 'ISO_IR 110',
+    'latin-5': 'ISO_IR 148',
+    'latin-9': 'ISO_IR 203',
+    cyrillic: 'ISO_IR 144',
+    arabic: 'ISO_IR 127',
+    greek: 'ISO_IR 126',
+    hebrew: 'ISO_IR 138',
+    thai: 'ISO_IR 166',
+    'shift-jis': 'ISO_IR 13',
+    shift_jis: 'ISO_IR 13',
+    'utf-8': 'ISO_IR 192',
+    utf8: 'ISO_IR 192',
+    gb18030: 'GB18030',
+    gbk: 'GBK',
+};
+
+/** Cache of TextDecoder instances by label ('' = construction failed). */
+const decoderCache = new Map<string, TextDecoder | undefined>();
+
+/** Returns a cached TextDecoder for a label, or undefined if unsupported. */
+function getTextDecoder(labelName: string): TextDecoder | undefined {
+    if (decoderCache.has(labelName)) {
+        return decoderCache.get(labelName);
+    }
+    let decoder: TextDecoder | undefined;
+    try {
+        decoder = new TextDecoder(labelName);
+    } catch {
+        decoder = undefined;
+    }
+    decoderCache.set(labelName, decoder);
+    return decoder;
+}
+
+/** Decodes bytes as ISO-8859-1 (every byte → U+00xx). */
+function decodeLatin1(bytes: Uint8Array): string {
+    return Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('latin1');
+}
+
+/** Decodes a single run of bytes with the given segment decoder. */
+function decodeSegment(bytes: Uint8Array, decoder: SegmentDecoder): string {
+    if (bytes.length === 0) return '';
+    switch (decoder.kind) {
+        case 'latin1':
+            return decodeLatin1(bytes);
+        case 'label': {
+            const td = getTextDecoder(decoder.label);
+            /* v8 ignore next -- labels in the tables are validated by resolveCharsets */
+            if (td === undefined) return decodeLatin1(bytes);
+            return td.decode(bytes);
+        }
+        case 'iso2022jp': {
+            const td = getTextDecoder('iso-2022-jp');
+            /* v8 ignore next -- iso-2022-jp is always available in Node with ICU */
+            if (td === undefined) return decodeLatin1(bytes);
+            const wrapped = new Uint8Array(decoder.escape.length + bytes.length);
+            wrapped.set(decoder.escape, 0);
+            wrapped.set(bytes, decoder.escape.length);
+            return td.decode(wrapped);
+        }
+        case 'katakana': {
+            const td = getTextDecoder('shift_jis');
+            /* v8 ignore next -- shift_jis is always available in Node with ICU */
+            if (td === undefined) return decodeLatin1(bytes);
+            return td.decode(bytes);
+        }
+    }
+}
+
+/** A recognized ISO 2022 escape sequence within a byte run. */
+interface EscapeMatch {
+    /** The bytes after ESC as a string key into ESCAPE_DECODERS. */
+    readonly key: string;
+    /** Total length of the escape sequence including the ESC byte. */
+    readonly length: number;
+}
+
+/**
+ * Reads an ISO 2022 escape sequence starting at `start` (which must point at
+ * an ESC byte). Intermediate bytes are 0x20-0x2F, the final byte 0x30-0x7E.
+ */
+function readEscape(bytes: Uint8Array, start: number): EscapeMatch {
+    let i = start + 1;
+    while (i < bytes.length && (bytes[i] as number) >= 0x20 && (bytes[i] as number) <= 0x2f) {
+        i++;
+    }
+    if (i < bytes.length && (bytes[i] as number) >= 0x30 && (bytes[i] as number) <= 0x7e) {
+        i++;
+    }
+    const seq = bytes.subarray(start + 1, i);
+    return { key: decodeLatin1(seq), length: i - start };
+}
+
+/**
+ * Decodes a byte run containing ISO 2022 escape sequences. Each escape
+ * switches the decoder for the following segment; unrecognized escapes
+ * leave the current decoder active.
+ */
+function decodeIso2022(bytes: Uint8Array, initial: SegmentDecoder): string {
+    let out = '';
+    let current = initial;
+    let segStart = 0;
+    let i = 0;
+    while (i < bytes.length) {
+        if (bytes[i] !== 0x1b) {
+            i++;
+            continue;
+        }
+        out += decodeSegment(bytes.subarray(segStart, i), current);
+        const esc = readEscape(bytes, i);
+        current = ESCAPE_DECODERS[esc.key] ?? current;
+        i += esc.length;
+        segStart = i;
+    }
+    out += decodeSegment(bytes.subarray(segStart), current);
+    return out;
+}
+
+/** A resolved character-set configuration for one dataset. */
+interface CharsetContext {
+    /** The normalized charset terms (first value of 0008,0005 first). */
+    readonly terms: readonly string[];
+    /** Whether ISO 2022 escape processing applies. */
+    readonly iso2022: boolean;
+    /** Decoder for non-2022 charsets, or the initial decoder for ISO 2022. */
+    readonly initial: SegmentDecoder;
+}
+
+/** The default context (ISO_IR 6 / ASCII). */
+const DEFAULT_CONTEXT: CharsetContext = { terms: ['ISO_IR 6'], iso2022: false, initial: LATIN1 };
+
+/** Normalizes a user-supplied charset name (alias or defined term) to a defined term, or undefined. */
+function normalizeCharsetName(input: string): string | undefined {
+    const trimmed = input.trim();
+    if (CHARSET_DECODERS[trimmed] !== undefined || ISO2022_INITIAL[trimmed] !== undefined) {
+        return trimmed;
+    }
+    return CHARSET_ALIASES[trimmed.toLowerCase()];
+}
+
+/** Builds a context from validated terms. */
+function buildContext(terms: readonly string[]): CharsetContext | undefined {
+    const iso2022 = terms.length > 1 || terms.some(t => t.startsWith('ISO 2022'));
+    const first = terms[0] ?? 'ISO_IR 6';
+    const initial = iso2022 ? ISO2022_INITIAL[first] : CHARSET_DECODERS[first];
+    if (initial === undefined) return undefined;
+    return { terms, iso2022, initial };
+}
+
+/** Parses raw SpecificCharacterSet values into normalized terms. An empty first value means the default repertoire. */
+function parseSpecificCharacterSet(raw: string): string[] {
+    const values = raw.split('\\').map(v => v.trim());
+    return values.map((v, idx) => (v === '' && idx === 0 ? 'ISO 2022 IR 6' : v)).filter(v => v !== '');
+}
+
+/** Resolves a context from terms, falling back per configuration. */
+function contextFromTerms(terms: readonly string[], fallback: string | undefined, source: string): Result<CharsetContext> {
+    const context = buildContext(terms);
+    if (context !== undefined) {
+        return ok(context);
+    }
+    if (fallback !== undefined) {
+        const fallbackTerm = normalizeCharsetName(fallback);
+        const fallbackContext = fallbackTerm !== undefined ? buildContext([fallbackTerm]) : undefined;
+        if (fallbackContext !== undefined) {
+            return ok(fallbackContext);
+        }
+        return err(new Error(`Unsupported charset fallback '${fallback}' (while handling unsupported ${source})`));
+    }
+    return err(new Error(`Unsupported character set: ${source} — provide charsetFallback (e.g. 'latin-1') to decode best-effort`));
+}
+
+/**
+ * Resolves the character-set context for a dataset.
+ *
+ * @param specificCharacterSet - Raw SpecificCharacterSet (0008,0005) value, or undefined if absent
+ * @param charsetAssume - Charset to assume when 0008,0005 is absent (alias or defined term)
+ * @param charsetFallback - Charset to use when the specified charset is unsupported
+ * @returns A Result with the resolved context
+ */
+function resolveCharsetContext(specificCharacterSet: string | undefined, charsetAssume?: string, charsetFallback?: string): Result<CharsetContext> {
+    if (specificCharacterSet === undefined || specificCharacterSet.trim() === '') {
+        if (charsetAssume === undefined) {
+            return ok(DEFAULT_CONTEXT);
+        }
+        const term = normalizeCharsetName(charsetAssume);
+        if (term === undefined) {
+            return contextFromTerms([charsetAssume], charsetFallback, `charsetAssume '${charsetAssume}'`);
+        }
+        return contextFromTerms([term], charsetFallback, `charsetAssume '${charsetAssume}'`);
+    }
+    const terms = parseSpecificCharacterSet(specificCharacterSet);
+    return contextFromTerms(terms, charsetFallback, `'${specificCharacterSet}' (0008,0005)`);
+}
+
+/**
+ * Decodes raw DICOM text bytes using the resolved character-set context.
+ * Multi-value / person-name splitting must be done on the returned string.
+ *
+ * @param bytes - The raw value bytes
+ * @param context - The context from {@link resolveCharsetContext}
+ * @returns The decoded string
+ */
+function decodeDicomText(bytes: Uint8Array, context: CharsetContext): string {
+    if (context.iso2022) {
+        return decodeIso2022(bytes, context.initial);
+    }
+    return decodeSegment(bytes, context.initial);
+}
+
+export { resolveCharsetContext, decodeDicomText, normalizeCharsetName, DEFAULT_CONTEXT };
+export type { CharsetContext };

--- a/src/tools/_p10ToJson.test.ts
+++ b/src/tools/_p10ToJson.test.ts
@@ -1,0 +1,309 @@
+import { deflateRawSync } from 'node:zlib';
+import { describe, it, expect } from 'vitest';
+import { parseDicomBuffer } from './_p10ToJson';
+import type { DicomJsonModel } from './_xmlToJson';
+import { TS, evenPad, explicitEl, implicitEl, sqExplicit, sqImplicit, encapsulatedPixelData, metaGroup, p10 } from '../../test/helpers/p10';
+
+/** Parses or fails the test. */
+function parse(buffer: Buffer, options?: { charsetAssume?: string; charsetFallback?: string }): DicomJsonModel {
+    const result = parseDicomBuffer(buffer, options);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw result.error;
+    return result.value.data;
+}
+
+describe('parseDicomBuffer — strings', () => {
+    it('parses single and multi-value string VRs with trailing padding trimmed', () => {
+        const data = parse(
+            p10(TS.explicitLE, [
+                explicitEl('00080060', 'CS', evenPad('CT')),
+                explicitEl('00080008', 'CS', evenPad('ORIGINAL\\PRIMARY ')),
+                explicitEl('00100020', 'LO', evenPad('PAT001 ')),
+            ])
+        );
+        expect(data['00080060']).toEqual({ vr: 'CS', Value: ['CT'] });
+        expect(data['00080008']).toEqual({ vr: 'CS', Value: ['ORIGINAL', 'PRIMARY'] });
+        expect(data['00100020']).toEqual({ vr: 'LO', Value: ['PAT001'] });
+    });
+
+    it('preserves empty positions in multi-value strings', () => {
+        const data = parse(p10(TS.explicitLE, [explicitEl('00080008', 'CS', evenPad('\\SECONDARY\\INTRAOPERATIVE'))]));
+        expect(data['00080008']).toEqual({ vr: 'CS', Value: ['', 'SECONDARY', 'INTRAOPERATIVE'] });
+    });
+
+    it('trims trailing NUL padding from UI values', () => {
+        const data = parse(p10(TS.explicitLE, [explicitEl('00080016', 'UI', evenPad('1.2.840.10008.5.1.4.1.1.7', '\0'))]));
+        expect(data['00080016']).toEqual({ vr: 'UI', Value: ['1.2.840.10008.5.1.4.1.1.7'] });
+    });
+
+    it('emits a bare element for zero-length values', () => {
+        const data = parse(p10(TS.explicitLE, [explicitEl('00100020', 'LO', Buffer.alloc(0))]));
+        expect(data['00100020']).toEqual({ vr: 'LO' });
+    });
+
+    it('emits a bare element for whitespace-only values', () => {
+        const data = parse(p10(TS.explicitLE, [explicitEl('00100020', 'LO', evenPad('  '))]));
+        expect(data['00100020']).toEqual({ vr: 'LO' });
+    });
+
+    it('does not split text VRs (ST/LT/UT/UR) on backslash', () => {
+        const data = parse(p10(TS.explicitLE, [explicitEl('00104000', 'LT', evenPad('line1\\line2'))]));
+        expect(data['00104000']).toEqual({ vr: 'LT', Value: ['line1\\line2'] });
+    });
+
+    it('coerces DS and IS values to numbers, keeping non-numeric strings', () => {
+        const data = parse(
+            p10(TS.explicitLE, [
+                explicitEl('00201041', 'DS', evenPad('-12.5\\+3.25')),
+                explicitEl('00200013', 'IS', evenPad('42')),
+                explicitEl('00181060', 'DS', evenPad('abc')),
+            ])
+        );
+        expect(data['00201041']).toEqual({ vr: 'DS', Value: [-12.5, 3.25] });
+        expect(data['00200013']).toEqual({ vr: 'IS', Value: [42] });
+        expect(data['00181060']).toEqual({ vr: 'DS', Value: ['abc'] });
+    });
+});
+
+describe('parseDicomBuffer — person names', () => {
+    it('parses PN component groups', () => {
+        const data = parse(p10(TS.explicitLE, [explicitEl('00100010', 'PN', evenPad('Smith^John^^Dr^'))]));
+        expect(data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'Smith^John^^Dr' }] });
+    });
+
+    it('parses multi-value PN and ideographic/phonetic groups', () => {
+        const utf8 = Buffer.from('Wang^XiaoDong=王^小东=', 'utf8');
+        const value = utf8.length % 2 === 0 ? utf8 : Buffer.concat([utf8, Buffer.from(' ')]);
+        const data = parse(
+            p10(TS.explicitLE, [
+                explicitEl('00080005', 'CS', evenPad('ISO_IR 192')),
+                explicitEl('00100010', 'PN', value),
+                explicitEl('00101001', 'PN', evenPad('A\\B')),
+            ])
+        );
+        expect(data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'Wang^XiaoDong', Ideographic: '王^小东' }] });
+        expect(data['00101001']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'A' }, { Alphabetic: 'B' }] });
+    });
+});
+
+describe('parseDicomBuffer — binary numeric VRs', () => {
+    it('parses US, SS, UL, SL, FL, FD arrays', () => {
+        const us = Buffer.alloc(4);
+        us.writeUInt16LE(1, 0);
+        us.writeUInt16LE(65535, 2);
+        const ss = Buffer.alloc(2);
+        ss.writeInt16LE(-5, 0);
+        const ul = Buffer.alloc(4);
+        ul.writeUInt32LE(4000000000, 0);
+        const sl = Buffer.alloc(4);
+        sl.writeInt32LE(-123456, 0);
+        const fl = Buffer.alloc(4);
+        fl.writeFloatLE(1.5, 0);
+        const fd = Buffer.alloc(8);
+        fd.writeDoubleLE(3.14159, 0);
+        const data = parse(
+            p10(TS.explicitLE, [
+                explicitEl('00280010', 'US', us),
+                explicitEl('00189219', 'SS', ss),
+                explicitEl('00081161', 'UL', ul),
+                explicitEl('0040A162', 'SL', sl),
+                explicitEl('00089459', 'FL', fl),
+                explicitEl('00189352', 'FD', fd),
+            ])
+        );
+        expect(data['00280010']).toEqual({ vr: 'US', Value: [1, 65535] });
+        expect(data['00189219']).toEqual({ vr: 'SS', Value: [-5] });
+        expect(data['00081161']).toEqual({ vr: 'UL', Value: [4000000000] });
+        expect(data['0040A162']).toEqual({ vr: 'SL', Value: [-123456] });
+        expect(data['00089459']).toEqual({ vr: 'FL', Value: [1.5] });
+        expect(data['00189352']).toEqual({ vr: 'FD', Value: [3.14159] });
+    });
+
+    it('parses SV and UV 64-bit values (implicit VR)', () => {
+        // dicom-parser mis-tokenizes explicit-VR SV/UV/OV (post-2019 VRs use
+        // the 12-byte form it doesn't know); implicit VR encodes lengths
+        // uniformly, so the 64-bit read path is exercised via implicit files.
+        const sv = Buffer.alloc(8);
+        sv.writeBigInt64LE(-42n, 0);
+        const uv = Buffer.alloc(8);
+        uv.writeBigUInt64LE(42n, 0);
+        const data = parse(p10(TS.implicitLE, [implicitEl('00720082', sv), implicitEl('00720083', uv)]));
+        expect(data['00720082']).toEqual({ vr: 'SV', Value: [-42] });
+        expect(data['00720083']).toEqual({ vr: 'UV', Value: [42] });
+    });
+
+    it('fails gracefully on explicit-VR SV values (known dicom-parser limitation)', () => {
+        const sv = Buffer.alloc(8);
+        sv.writeBigInt64LE(-42n, 0);
+        const result = parseDicomBuffer(p10(TS.explicitLE, [explicitEl('00720082', 'SV', sv)]));
+        expect(result.ok).toBe(false);
+    });
+
+    it('parses AT values as GGGGEEEE strings', () => {
+        const at = Buffer.alloc(8);
+        at.writeUInt16LE(0x0018, 0);
+        at.writeUInt16LE(0x1063, 2);
+        at.writeUInt16LE(0x0028, 4);
+        at.writeUInt16LE(0x0010, 6);
+        const data = parse(p10(TS.explicitLE, [explicitEl('00280009', 'AT', at)]));
+        expect(data['00280009']).toEqual({ vr: 'AT', Value: ['00181063', '00280010'] });
+    });
+
+    it('emits bare elements for truncated numeric and AT values', () => {
+        const data = parse(p10(TS.explicitLE, [explicitEl('00280010', 'US', Buffer.alloc(1)), explicitEl('00280009', 'AT', Buffer.alloc(2))]));
+        expect(data['00280010']).toEqual({ vr: 'US' });
+        expect(data['00280009']).toEqual({ vr: 'AT' });
+    });
+});
+
+describe('parseDicomBuffer — binary and pixel data', () => {
+    it('emits bare elements for bulk binary VRs', () => {
+        const data = parse(
+            p10(TS.explicitLE, [
+                explicitEl('7FE00010', 'OW', Buffer.alloc(16)),
+                explicitEl('00291002', 'OB', Buffer.alloc(4)),
+                explicitEl('00291004', 'UN', Buffer.alloc(4)),
+            ])
+        );
+        expect(data['7FE00010']).toEqual({ vr: 'OW' });
+        expect(data['00291002']).toEqual({ vr: 'OB' });
+        expect(data['00291004']).toEqual({ vr: 'UN' });
+    });
+
+    it('normalizes encapsulated pixel data to OB', () => {
+        const data = parse(p10(TS.jpegBaseline, [encapsulatedPixelData(Buffer.alloc(8))]));
+        expect(data['7FE00010']).toEqual({ vr: 'OB' });
+    });
+});
+
+describe('parseDicomBuffer — sequences', () => {
+    it('parses nested defined-length sequences', () => {
+        const itemContent = Buffer.concat([
+            explicitEl('00081150', 'UI', evenPad('1.2.840.10008.5.1.4.1.1.4', '\0')),
+            explicitEl('00081155', 'UI', evenPad('1.2.3.4', '\0')),
+        ]);
+        const outer = sqExplicit('00081140', [itemContent, itemContent]);
+        const data = parse(p10(TS.explicitLE, [outer]));
+        expect(data['00081140']?.vr).toBe('SQ');
+        const items = data['00081140']?.Value as readonly DicomJsonModel[];
+        expect(items).toHaveLength(2);
+        expect(items[0]?.['00081155']).toEqual({ vr: 'UI', Value: ['1.2.3.4'] });
+    });
+
+    it('parses two-level nesting', () => {
+        const level2 = Buffer.concat([explicitEl('00080100', 'SH', evenPad('CODE'))]);
+        const level1 = Buffer.concat([explicitEl('00081032', 'SQ', Buffer.alloc(0)), sqExplicit('00080096', [level2])]);
+        const data = parse(p10(TS.explicitLE, [sqExplicit('00081110', [level1])]));
+        const item0 = (data['00081110']?.Value as readonly DicomJsonModel[])[0];
+        expect(item0?.['00081032']).toEqual({ vr: 'SQ' });
+        const nested = (item0?.['00080096']?.Value as readonly DicomJsonModel[])[0];
+        expect(nested?.['00080100']).toEqual({ vr: 'SH', Value: ['CODE'] });
+    });
+
+    it('emits a bare SQ for zero-length sequences', () => {
+        const data = parse(p10(TS.explicitLE, [explicitEl('00081140', 'SQ', Buffer.alloc(0))]));
+        expect(data['00081140']).toEqual({ vr: 'SQ' });
+    });
+
+    it('represents empty items as empty objects', () => {
+        const data = parse(p10(TS.explicitLE, [sqExplicit('00081140', [Buffer.alloc(0)])]));
+        expect(data['00081140']).toEqual({ vr: 'SQ', Value: [{}] });
+    });
+});
+
+describe('parseDicomBuffer — transfer syntaxes', () => {
+    it('parses implicit VR little endian using the dictionary', () => {
+        const data = parse(p10(TS.implicitLE, [implicitEl('00100010', evenPad('Smith^John')), implicitEl('00100020', evenPad('PAT001'))]));
+        expect(data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'Smith^John' }] });
+        expect(data['00100020']).toEqual({ vr: 'LO', Value: ['PAT001'] });
+    });
+
+    it('parses implicit VR sequences using the dictionary', () => {
+        const itemContent = implicitEl('00081155', evenPad('1.2.3.4', '\0'));
+        const data = parse(p10(TS.implicitLE, [sqImplicit('00081140', [itemContent])]));
+        expect(data['00081140']?.vr).toBe('SQ');
+        const items = data['00081140']?.Value as readonly DicomJsonModel[];
+        expect(items[0]?.['00081155']).toEqual({ vr: 'UI', Value: ['1.2.3.4'] });
+    });
+
+    it('maps unknown private implicit elements to UN', () => {
+        const data = parse(p10(TS.implicitLE, [implicitEl('00990001', evenPad('mystery'))]));
+        expect(data['00990001']).toEqual({ vr: 'UN' });
+    });
+
+    it('parses explicit VR big endian', () => {
+        const us = Buffer.alloc(2);
+        us.writeUInt16BE(256, 0);
+        const data = parse(p10(TS.explicitBE, [explicitEl('00280010', 'US', us, true), explicitEl('00100020', 'LO', evenPad('PAT001'), true)]));
+        expect(data['00280010']).toEqual({ vr: 'US', Value: [256] });
+        expect(data['00100020']).toEqual({ vr: 'LO', Value: ['PAT001'] });
+    });
+
+    it('parses the deflated transfer syntax via node:zlib', () => {
+        const dataset = Buffer.concat([explicitEl('00100020', 'LO', evenPad('PAT001'))]);
+        const deflated = deflateRawSync(dataset);
+        const buffer = Buffer.concat([Buffer.alloc(128), Buffer.from('DICM', 'latin1'), metaGroup(TS.deflatedLE), deflated]);
+        const data = parse(buffer);
+        expect(data['00100020']).toEqual({ vr: 'LO', Value: ['PAT001'] });
+    });
+});
+
+describe('parseDicomBuffer — charset integration', () => {
+    it('decodes charset-sensitive VRs using SpecificCharacterSet', () => {
+        const cyrillic = Buffer.from('\xbb\xee\xda\xe1\xd5\xdc\xd1\xe3\xe0\xd3', 'latin1');
+        const data = parse(p10(TS.explicitLE, [explicitEl('00080005', 'CS', evenPad('ISO_IR 144')), explicitEl('00100010', 'PN', cyrillic)]));
+        expect(data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'Люксембург' }] });
+    });
+
+    it('applies charsetAssume when 0008,0005 is absent', () => {
+        const data = parse(p10(TS.explicitLE, [explicitEl('00100010', 'PN', evenPad('M\xfcller'))]), { charsetAssume: 'latin-1' });
+        expect(data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'Müller' }] });
+    });
+
+    it('lets a nested item override the charset', () => {
+        const utf8Name = Buffer.from('王', 'utf8');
+        const padded = utf8Name.length % 2 === 0 ? utf8Name : Buffer.concat([utf8Name, Buffer.from(' ')]);
+        const itemContent = Buffer.concat([explicitEl('00080005', 'CS', evenPad('ISO_IR 192')), explicitEl('00100010', 'PN', padded)]);
+        const data = parse(p10(TS.explicitLE, [explicitEl('00080005', 'CS', evenPad('ISO_IR 100')), sqExplicit('00081140', [itemContent])]));
+        const item0 = (data['00081140']?.Value as readonly DicomJsonModel[])[0];
+        expect(item0?.['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: '王' }] });
+    });
+
+    it('errors on unsupported charsets without a fallback and succeeds with one', () => {
+        const file = p10(TS.explicitLE, [explicitEl('00080005', 'CS', evenPad('ISO_IR 999')), explicitEl('00100010', 'PN', evenPad('X'))]);
+        const failed = parseDicomBuffer(file);
+        expect(failed.ok).toBe(false);
+        const data = parse(file, { charsetFallback: 'latin-1' });
+        expect(data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'X' }] });
+    });
+});
+
+describe('parseDicomBuffer — structure and errors', () => {
+    it('includes file meta group 0002 and omits group lengths', () => {
+        const data = parse(p10(TS.explicitLE, [explicitEl('00100020', 'LO', evenPad('PAT001'))]));
+        expect(data['00020010']).toEqual({ vr: 'UI', Value: [TS.explicitLE] });
+        expect(data['00020000']).toBeUndefined();
+    });
+
+    it('resolves unknown explicit VR codes to UN', () => {
+        const data = parse(p10(TS.explicitLE, [explicitEl('00090001', 'ZZ', evenPad('what'))]));
+        expect(data['00090001']).toEqual({ vr: 'UN' });
+    });
+
+    it('returns an error for non-DICOM input', () => {
+        const result = parseDicomBuffer(Buffer.from('this is not dicom at all, definitely longer than 132 bytes'.repeat(4)));
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error.message).toContain('Failed to parse DICOM data');
+    });
+
+    it('returns an error for an empty buffer', () => {
+        const result = parseDicomBuffer(Buffer.alloc(0));
+        expect(result.ok).toBe(false);
+    });
+
+    it('surfaces tokenizer warnings', () => {
+        const result = parseDicomBuffer(p10(TS.explicitLE, [explicitEl('00100020', 'LO', evenPad('PAT001'))]));
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(Array.isArray(result.value.warnings)).toBe(true);
+    });
+});

--- a/src/tools/_p10ToJson.ts
+++ b/src/tools/_p10ToJson.ts
@@ -1,0 +1,343 @@
+/**
+ * Pure-JS DICOM Part-10 → DICOM JSON Model (PS3.18 F.2) conversion.
+ *
+ * Tokenizes with `dicom-parser` and converts elements to the same JSON shape
+ * the dcm2xml path produces, with two documented differences:
+ * - File meta group 0002 elements are included (the XML path omits them),
+ *   which makes `DicomDataset.transferSyntaxUID` functional.
+ * - Group length elements (gggg,0000) are always omitted.
+ *
+ * Bulk binary VRs (OB/OW/OD/OF/OL/OV/UN) are emitted as bare `{ vr }` with no
+ * value — matching the XML path, which never loads binary data.
+ *
+ * Sequence traversal is iterative (explicit work stack, Rule 8.2).
+ *
+ * @module _p10ToJson
+ * @internal
+ */
+
+import { inflateRawSync } from 'node:zlib';
+import dicomParser from 'dicom-parser';
+import type { DataSet, Element } from 'dicom-parser';
+import { stderr } from 'stderr-lib';
+import type { Result } from '../types';
+import { ok, err } from '../types';
+import { lookupTag } from '../dicom/dictionary';
+import { decodeDicomText, resolveCharsetContext } from './_charset';
+import type { CharsetContext } from './_charset';
+import { coerceNumeric, KNOWN_VR_CODES } from './_xmlToJson';
+import type { DicomJsonModel, DicomJsonElement } from './_xmlToJson';
+
+/** Options for {@link parseDicomBuffer}. */
+interface P10ParseOptions {
+    /** Charset to assume when SpecificCharacterSet (0008,0005) is absent. */
+    readonly charsetAssume?: string | undefined;
+    /** Charset to fall back to when the specified charset is unsupported. */
+    readonly charsetFallback?: string | undefined;
+}
+
+/** Result of a successful buffer parse. */
+interface P10ParseResult {
+    /** The DICOM JSON Model. */
+    readonly data: DicomJsonModel;
+    /** Non-fatal warnings collected by the tokenizer. */
+    readonly warnings: readonly string[];
+}
+
+/** VRs whose values are bulk binary and are never loaded (bare `{ vr }`). */
+const BINARY_VRS = new Set(['OB', 'OW', 'OD', 'OF', 'OL', 'OV', 'UN']);
+
+/** VRs holding text that SpecificCharacterSet applies to. */
+const CHARSET_VRS = new Set(['SH', 'LO', 'ST', 'LT', 'UC', 'UT', 'PN']);
+
+/** Text VRs with VM 1 whose value may contain backslashes (never split). */
+const NO_SPLIT_VRS = new Set(['ST', 'LT', 'UT', 'UR']);
+
+/** Fixed-width binary numeric VRs → byte size per value. */
+const NUMERIC_VR_SIZE: Readonly<Record<string, number>> = { US: 2, SS: 2, UL: 4, SL: 4, FL: 4, FD: 8, SV: 8, UV: 8 };
+
+/** Bound on total datasets (root + sequence items) traversed per file (Rule 8.2). */
+const MAX_DATASETS = 100_000;
+
+/** Converts a dicom-parser tag ('x00100010') to a JSON Model tag ('00100010'). */
+function toJsonTag(tag: string): string {
+    return tag.slice(1).toUpperCase();
+}
+
+/**
+ * True for elements that are encoding artifacts, not data: group length
+ * elements (gggg,0000) and item/sequence delimitation tags (group FFFE),
+ * which dicom-parser surfaces inside undefined-length items.
+ */
+function isEncodingArtifact(tag: string): boolean {
+    return (tag.endsWith('0000') && tag.length === 9) || tag.startsWith('xfffe');
+}
+
+/** Resolves the effective VR for an element (explicit VR, dictionary result, or UN). */
+function resolveVr(element: Element): string {
+    const vr = element.vr;
+    if (vr !== undefined && KNOWN_VR_CODES.has(vr)) {
+        return vr;
+    }
+    return 'UN';
+}
+
+/** Returns the value bytes of an element. */
+function valueBytes(element: Element, byteArray: Uint8Array): Uint8Array {
+    return byteArray.subarray(element.dataOffset, element.dataOffset + element.length);
+}
+
+/** Trims trailing space and null padding from a decoded string value. */
+function trimPadding(value: string): string {
+    let end = value.length;
+    while (end > 0) {
+        const ch = value.charCodeAt(end - 1);
+        if (ch !== 0x20 && ch !== 0x00) break;
+        end--;
+    }
+    return value.slice(0, end);
+}
+
+/** Reads one fixed-width numeric value at the given offset. */
+function readNumericAt(view: DataView, offset: number, vr: string, littleEndian: boolean): number {
+    switch (vr) {
+        case 'US':
+            return view.getUint16(offset, littleEndian);
+        case 'SS':
+            return view.getInt16(offset, littleEndian);
+        case 'UL':
+            return view.getUint32(offset, littleEndian);
+        case 'SL':
+            return view.getInt32(offset, littleEndian);
+        case 'FL':
+            return view.getFloat32(offset, littleEndian);
+        case 'FD':
+            return view.getFloat64(offset, littleEndian);
+        case 'SV':
+            return Number(view.getBigInt64(offset, littleEndian));
+        /* v8 ignore next 2 -- 'UV' is the only remaining caller-provided VR */
+        default:
+            return Number(view.getBigUint64(offset, littleEndian));
+    }
+}
+
+/** Converts a fixed-width binary numeric element. */
+function convertNumeric(element: Element, byteArray: Uint8Array, vr: string, littleEndian: boolean): DicomJsonElement {
+    const size = NUMERIC_VR_SIZE[vr] as number;
+    const count = Math.floor(element.length / size);
+    if (count === 0) {
+        return { vr };
+    }
+    const view = new DataView(byteArray.buffer, byteArray.byteOffset + element.dataOffset, element.length);
+    const values: number[] = [];
+    for (let i = 0; i < count; i++) {
+        values.push(readNumericAt(view, i * size, vr, littleEndian));
+    }
+    return { vr, Value: values };
+}
+
+/** Converts an AT (attribute tag) element to 'GGGGEEEE' strings. */
+function convertAttributeTag(element: Element, byteArray: Uint8Array, littleEndian: boolean): DicomJsonElement {
+    const count = Math.floor(element.length / 4);
+    if (count === 0) {
+        return { vr: 'AT' };
+    }
+    const view = new DataView(byteArray.buffer, byteArray.byteOffset + element.dataOffset, element.length);
+    const values: string[] = [];
+    for (let i = 0; i < count; i++) {
+        const group = view.getUint16(i * 4, littleEndian);
+        const elem = view.getUint16(i * 4 + 2, littleEndian);
+        values.push(group.toString(16).padStart(4, '0').toUpperCase() + elem.toString(16).padStart(4, '0').toUpperCase());
+    }
+    return { vr: 'AT', Value: values };
+}
+
+/** Splits a decoded person-name value into its PS3.18 component-group object. */
+function personNameToJson(value: string): Record<string, string> {
+    const groups = trimPadding(value).split('=');
+    const result: Record<string, string> = {};
+    const names: readonly string[] = ['Alphabetic', 'Ideographic', 'Phonetic'];
+    for (let i = 0; i < names.length; i++) {
+        const group = (groups[i] ?? '').replace(/\^+$/u, '');
+        const name = names[i];
+        if (group !== '' && name !== undefined) {
+            result[name] = group;
+        }
+    }
+    return result;
+}
+
+/** Converts a PN element. */
+function convertPersonName(element: Element, byteArray: Uint8Array, charset: CharsetContext): DicomJsonElement {
+    const decoded = decodeDicomText(valueBytes(element, byteArray), charset);
+    const values = decoded.split('\\').map(personNameToJson);
+    return { vr: 'PN', Value: values };
+}
+
+/** Converts a text/string element (everything except SQ, PN, AT, binary, and fixed-width numerics). */
+function convertString(element: Element, byteArray: Uint8Array, vr: string, charset: CharsetContext): DicomJsonElement {
+    const bytes = valueBytes(element, byteArray);
+    const decoded = CHARSET_VRS.has(vr) ? decodeDicomText(bytes, charset) : Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('latin1');
+    const rawValues = NO_SPLIT_VRS.has(vr) ? [decoded] : decoded.split('\\');
+    const values: unknown[] = rawValues.map(v => {
+        const trimmed = trimPadding(v);
+        return vr === 'DS' || vr === 'IS' ? coerceNumeric(trimmed.trim()) : trimmed;
+    });
+    if (values.length === 1 && values[0] === '') {
+        return { vr };
+    }
+    return { vr, Value: values };
+}
+
+/** Per-dataset conversion settings threaded through element conversion. */
+interface ConvertSettings {
+    readonly charset: CharsetContext;
+    readonly littleEndian: boolean;
+}
+
+/** Converts a non-sequence element to its DICOM JSON representation. */
+function convertLeaf(element: Element, byteArray: Uint8Array, vr: string, settings: ConvertSettings): DicomJsonElement {
+    if (element.fragments !== undefined) {
+        // Encapsulated pixel data is OB by definition (PS3.5 A.4); DCMTK
+        // applies the same correction to files carrying a wrong explicit VR.
+        return { vr: 'OB' };
+    }
+    if (BINARY_VRS.has(vr)) {
+        return { vr };
+    }
+    if (element.length === 0) {
+        return { vr };
+    }
+    if (NUMERIC_VR_SIZE[vr] !== undefined) {
+        return convertNumeric(element, byteArray, vr, settings.littleEndian);
+    }
+    if (vr === 'AT') {
+        return convertAttributeTag(element, byteArray, settings.littleEndian);
+    }
+    if (vr === 'PN') {
+        return convertPersonName(element, byteArray, settings.charset);
+    }
+    return convertString(element, byteArray, vr, settings.charset);
+}
+
+/** A pending dataset conversion unit for the iterative sequence walk. */
+interface WorkUnit {
+    readonly src: DataSet;
+    readonly out: Record<string, DicomJsonElement>;
+    readonly parentCharset: CharsetContext;
+}
+
+/** Resolves the charset context for a dataset, inheriting from the parent when 0008,0005 is absent. */
+function datasetCharset(src: DataSet, parent: CharsetContext, options: P10ParseOptions | undefined): Result<CharsetContext> {
+    const raw = src.string('x00080005');
+    if (raw === undefined) {
+        return ok(parent);
+    }
+    return resolveCharsetContext(raw, undefined, options?.charsetFallback);
+}
+
+/** Converts a sequence element, queueing item datasets onto the work stack. */
+function convertSequence(element: Element, stack: WorkUnit[], charset: CharsetContext): DicomJsonElement {
+    const items = element.items ?? [];
+    const values: Record<string, DicomJsonElement>[] = [];
+    for (const item of items) {
+        const model: Record<string, DicomJsonElement> = {};
+        values.push(model);
+        if (item.dataSet !== undefined) {
+            stack.push({ src: item.dataSet, out: model, parentCharset: charset });
+        }
+    }
+    if (values.length === 0) {
+        return { vr: 'SQ' };
+    }
+    return { vr: 'SQ', Value: values };
+}
+
+/** True when the element should be converted as a sequence. */
+function isSequence(element: Element, vr: string): boolean {
+    if (element.fragments !== undefined) {
+        return false;
+    }
+    return vr === 'SQ' || (element.vr === undefined && element.items !== undefined);
+}
+
+/** Converts all elements of one dataset into its output model. */
+function convertDataset(unit: WorkUnit, stack: WorkUnit[], littleEndian: boolean, options: P10ParseOptions | undefined): Result<void> {
+    const charsetResult = datasetCharset(unit.src, unit.parentCharset, options);
+    if (!charsetResult.ok) {
+        return err(charsetResult.error);
+    }
+    const charset = charsetResult.value;
+    const keys = Object.keys(unit.src.elements).sort();
+    for (const key of keys) {
+        const element = unit.src.elements[key];
+        /* v8 ignore next -- keys come from the object itself */
+        if (element === undefined) continue;
+        if (isEncodingArtifact(element.tag)) continue;
+        const tag = toJsonTag(element.tag);
+        const vr = resolveVr(element);
+        if (isSequence(element, vr)) {
+            unit.out[tag] = convertSequence(element, stack, charset);
+        } else {
+            unit.out[tag] = convertLeaf(element, unit.src.byteArray, vr, { charset, littleEndian });
+        }
+    }
+    return ok(undefined);
+}
+
+/** Inflater for the deflated transfer syntax, backed by node:zlib. */
+function inflateDeflated(byteArray: Uint8Array, position: number): Uint8Array {
+    const inflated = inflateRawSync(byteArray.subarray(position));
+    const combined = new Uint8Array(position + inflated.byteLength);
+    combined.set(byteArray.subarray(0, position), 0);
+    combined.set(inflated, position);
+    return combined;
+}
+
+/** VR resolver for implicit transfer syntaxes, backed by the tag dictionary. */
+function implicitVrLookup(tag: string): string | undefined {
+    return lookupTag(tag.slice(1))?.vr;
+}
+
+/**
+ * Parses a DICOM Part-10 buffer (or raw dataset) into the DICOM JSON Model.
+ *
+ * @param buffer - The file bytes
+ * @param options - Charset handling options
+ * @returns A Result with the JSON Model and tokenizer warnings
+ */
+function parseDicomBuffer(buffer: Uint8Array, options?: P10ParseOptions): Result<P10ParseResult> {
+    let dataSet: DataSet;
+    try {
+        dataSet = dicomParser.parseDicom(buffer, { vrCallback: implicitVrLookup, inflater: inflateDeflated });
+    } catch (error: unknown) {
+        return err(new Error(`Failed to parse DICOM data: ${stderr(error).message}`));
+    }
+
+    const littleEndian = dataSet.string('x00020010') !== '1.2.840.10008.1.2.2';
+    const rootCharset = resolveCharsetContext(undefined, options?.charsetAssume, options?.charsetFallback);
+    if (!rootCharset.ok) {
+        return err(rootCharset.error);
+    }
+
+    const data: Record<string, DicomJsonElement> = {};
+    const stack: WorkUnit[] = [{ src: dataSet, out: data, parentCharset: rootCharset.value }];
+    let processed = 0;
+    while (stack.length > 0) {
+        processed++;
+        if (processed > MAX_DATASETS) {
+            return err(new Error(`Failed to parse DICOM data: more than ${String(MAX_DATASETS)} nested datasets`));
+        }
+        const unit = stack.pop();
+        /* v8 ignore next -- stack.length > 0 guarantees an entry */
+        if (unit === undefined) break;
+        const converted = convertDataset(unit, stack, littleEndian, options);
+        if (!converted.ok) {
+            return err(converted.error);
+        }
+    }
+    return ok({ data, warnings: dataSet.warnings });
+}
+
+export { parseDicomBuffer };
+export type { P10ParseOptions, P10ParseResult };

--- a/src/tools/_xmlToJson.test.ts
+++ b/src/tools/_xmlToJson.test.ts
@@ -152,6 +152,22 @@ describe('xmlToJson()', () => {
         }
     });
 
+    it('decodes empty value positions as empty strings, not the number attribute', () => {
+        const xml = `<?xml version="1.0"?>
+<NativeDicomModel>
+  <DicomAttribute tag="00080008" vr="CS" keyword="ImageType">
+    <Value number="1"/>
+    <Value number="2">SECONDARY</Value>
+  </DicomAttribute>
+</NativeDicomModel>`;
+        const result = xmlToJson(xml);
+
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value['00080008']).toEqual({ vr: 'CS', Value: ['', 'SECONDARY'] });
+        }
+    });
+
     it('converts multiple elements', () => {
         const result = xmlToJson(MULTI_ELEMENT_XML);
 

--- a/src/tools/_xmlToJson.ts
+++ b/src/tools/_xmlToJson.ts
@@ -235,14 +235,19 @@ function convertSequence(attr: XmlDicomAttribute, element: ElementBuilder): void
 /** VRs whose values MUST be JSON numbers per DICOM PS3.18 F.2.3. */
 const NUMERIC_JSON_VRS = new Set(['DS', 'FL', 'FD', 'IS', 'SL', 'SS', 'SV', 'UL', 'US', 'UV']);
 
-/** Unwraps fast-xml-parser attribute wrapper objects (e.g., {@_number: "1"}). */
+/**
+ * Unwraps fast-xml-parser attribute wrapper objects (e.g., {'#text': 'v', '@_number': '1'}).
+ * An attribute-only object is an empty element (`<Value number="1"/>`) and
+ * unwraps to the empty string — returning the attribute value here would leak
+ * the value ordinal as the element value.
+ */
 function unwrapValue(v: unknown): unknown {
     if (typeof v !== 'object' || v === null) return v;
     const obj = v as Record<string, unknown>;
     if ('#text' in obj) return obj['#text'];
     const keys = Object.keys(obj);
-    if (keys.length === 1 && keys[0] !== undefined && keys[0].startsWith('@_')) {
-        return obj[keys[0]];
+    if (keys.every(k => k.startsWith('@_'))) {
+        return '';
     }
     return v;
 }
@@ -346,5 +351,5 @@ function xmlToJson(xml: string): Result<DicomJsonModel> {
     }
 }
 
-export { xmlToJson };
+export { xmlToJson, coerceNumeric, KNOWN_VR_CODES, NUMERIC_JSON_VRS };
 export type { DicomJsonModel, DicomJsonElement };

--- a/src/tools/dcm2json.test.ts
+++ b/src/tools/dcm2json.test.ts
@@ -178,5 +178,47 @@ describe('dcm2json', () => {
             const result = await dcm2json('/input.dcm');
             expect(result.ok).toBe(false);
         });
+
+        it('aggregates both path errors when both paths fail', async () => {
+            mockedExecCommand
+                .mockResolvedValueOnce({ ok: false, error: new Error('dcm2xml timed out') })
+                .mockResolvedValueOnce({ ok: false, error: new Error('dcm2json crashed') });
+            const result = await dcm2json('/input.dcm');
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                expect(result.error.message).toContain('both paths failed');
+                expect(result.error.message).toContain('dcm2xml timed out');
+                expect(result.error.message).toContain('dcm2json crashed');
+            }
+        });
+
+        it('skips the direct fallback when the timeout budget is exhausted', async () => {
+            mockedExecCommand.mockResolvedValue({ ok: false, error: new Error('dcm2xml timed out after 5000ms') });
+            const nowSpy = vi.spyOn(Date, 'now');
+            nowSpy.mockReturnValueOnce(0).mockReturnValueOnce(5_001);
+            const result = await dcm2json('/input.dcm', { timeoutMs: 5000 });
+            nowSpy.mockRestore();
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                expect(result.error.message).toContain('timeout budget');
+                expect(result.error.message).toContain('skipping direct fallback');
+                expect(result.error.message).toContain('dcm2xml timed out after 5000ms');
+            }
+            // The direct path must never have been launched
+            expect(mockedExecCommand).toHaveBeenCalledTimes(1);
+        });
+
+        it('runs the direct fallback with the remaining budget, not a fixed floor', async () => {
+            mockedExecCommand
+                .mockResolvedValueOnce({ ok: false, error: new Error('xml failed fast') })
+                .mockResolvedValueOnce({ ok: true, value: { stdout: '{}', stderr: '', exitCode: 0 } });
+            const nowSpy = vi.spyOn(Date, 'now');
+            nowSpy.mockReturnValueOnce(0).mockReturnValueOnce(2_000);
+            const result = await dcm2json('/input.dcm', { timeoutMs: 5000 });
+            nowSpy.mockRestore();
+            expect(result.ok).toBe(true);
+            const directCall = mockedExecCommand.mock.calls[1];
+            expect(directCall?.[2]).toEqual(expect.objectContaining({ timeoutMs: 3_000 }));
+        });
     });
 });

--- a/src/tools/dcm2json.ts
+++ b/src/tools/dcm2json.ts
@@ -179,11 +179,19 @@ async function execAndParse(
 }
 
 /**
- * Converts a DICOM file to the DICOM JSON Model.
+ * Converts a DICOM file to the DICOM JSON Model using DCMTK binaries.
  *
  * Uses a two-phase strategy:
  * 1. Primary: dcm2xml → XML-to-JSON conversion (more reliable)
  * 2. Fallback: direct dcm2json binary with JSON repair
+ *
+ * The fallback only runs when time budget remains; when both paths fail,
+ * the returned error includes both failures.
+ *
+ * @deprecated Use {@link dicom2json} — the pure-JS parser is ~75x faster,
+ * needs no DCMTK binaries, and preserves private tags correctly (this
+ * binary path renumbers private blocks in its XML output). This function
+ * remains available as an escape hatch (see `dcmtkFallback` on dicom2json).
  *
  * @param inputPath - Path to the DICOM input file
  * @param options - Conversion options
@@ -207,23 +215,50 @@ async function dcm2json(inputPath: string, options?: Dcm2jsonOptions): Promise<R
     const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     const signal = options?.signal;
     const startTime = Date.now();
-    const remaining = (): number => Math.max(1000, timeoutMs - (Date.now() - startTime));
+    const remaining = (): number => Math.max(0, timeoutMs - (Date.now() - startTime));
 
     const verbosity = options?.verbosity;
 
     // Direct-only mode: skip XML path
     if (options?.directOnly === true) {
-        return tryDirectPath(inputPath, remaining(), signal, verbosity);
+        return tryDirectPath(inputPath, timeoutMs, signal, verbosity);
     }
 
     // Try XML path first
-    const xmlResult = await tryXmlPath(inputPath, remaining(), signal, buildXmlOpts(options));
+    const xmlResult = await tryXmlPath(inputPath, timeoutMs, signal, buildXmlOpts(options));
     if (xmlResult.ok) {
         return xmlResult;
     }
 
-    // Fall back to direct path with remaining time budget
-    return tryDirectPath(inputPath, remaining(), signal, verbosity);
+    return fallbackToDirect(inputPath, xmlResult.error, { budget: remaining(), timeoutMs, signal, verbosity });
+}
+
+/** Context for the direct-path fallback after an XML path failure. */
+interface FallbackContext {
+    readonly budget: number;
+    readonly timeoutMs: number;
+    readonly signal?: AbortSignal | undefined;
+    readonly verbosity?: 'verbose' | 'debug' | undefined;
+}
+
+/**
+ * Runs the direct-path fallback only if time budget remains — a doomed
+ * fallback would time out immediately and mask the XML path's error.
+ * When both paths fail, the returned error includes both failures.
+ */
+async function fallbackToDirect(inputPath: string, xmlError: Error, context: FallbackContext): Promise<Result<Dcm2jsonResult>> {
+    if (context.budget === 0) {
+        return err(
+            new Error(
+                `dcm2json: XML path failed and timeout budget (${String(context.timeoutMs)}ms) is exhausted (skipping direct fallback) | xml: ${xmlError.message}`
+            )
+        );
+    }
+    const directResult = await tryDirectPath(inputPath, context.budget, context.signal, context.verbosity);
+    if (directResult.ok) {
+        return directResult;
+    }
+    return err(new Error(`dcm2json: both paths failed | xml: ${xmlError.message} | direct: ${directResult.error.message}`));
 }
 
 export { dcm2json };

--- a/src/tools/dicom2json.test.ts
+++ b/src/tools/dicom2json.test.ts
@@ -1,0 +1,158 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { ok, err } from '../types';
+import { TS, evenPad, explicitEl, p10 } from '../../test/helpers/p10';
+
+vi.mock('./dcm2json', () => ({
+    dcm2json: vi.fn(),
+}));
+
+import { dcm2json } from './dcm2json';
+import { dicom2json, dicom2jsonFromBuffer } from './dicom2json';
+
+const mockedDcm2json = vi.mocked(dcm2json);
+
+const VALID_FILE = p10(TS.explicitLE, [explicitEl('00100010', 'PN', evenPad('Smith^John')), explicitEl('00100020', 'LO', evenPad('PAT001'))]);
+
+let tempDir: string;
+let validPath: string;
+let garbagePath: string;
+
+beforeEach(async () => {
+    vi.clearAllMocks();
+    if (tempDir === undefined) {
+        tempDir = await mkdtemp(join(tmpdir(), 'dicom2json-test-'));
+        validPath = join(tempDir, 'valid.dcm');
+        garbagePath = join(tempDir, 'garbage.dcm');
+        await writeFile(validPath, VALID_FILE);
+        await writeFile(garbagePath, Buffer.from('not dicom '.repeat(20)));
+    }
+});
+
+afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('dicom2json', () => {
+    it('parses a DICOM file to the JSON Model', async () => {
+        const result = await dicom2json(validPath);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.source).toBe('js');
+            expect(result.value.data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'Smith^John' }] });
+            expect(result.value.data['00100020']).toEqual({ vr: 'LO', Value: ['PAT001'] });
+            expect(result.value.warnings).toEqual([]);
+        }
+    });
+
+    it('rejects unknown options', async () => {
+        const result = await dicom2json(validPath, { bogus: true } as never);
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error.message).toContain('invalid options');
+    });
+
+    it('rejects invalid option types', async () => {
+        const result = await dicom2json(validPath, { timeoutMs: -1 });
+        expect(result.ok).toBe(false);
+    });
+
+    it('returns a read error for a missing file', async () => {
+        const result = await dicom2json(join(tempDir, 'nope.dcm'));
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error.message).toContain('failed to read');
+    });
+
+    it('returns an abort error when the signal is already aborted', async () => {
+        const controller = new AbortController();
+        controller.abort();
+        const result = await dicom2json(validPath, { signal: controller.signal });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error.message).toContain('aborted');
+    });
+
+    it('returns the parse error without fallback by default', async () => {
+        const result = await dicom2json(garbagePath);
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error.message).toContain('Failed to parse DICOM data');
+        expect(mockedDcm2json).not.toHaveBeenCalled();
+    });
+
+    it('falls back to dcm2json when dcmtkFallback is set', async () => {
+        const fallbackData = { '00100020': { vr: 'LO', Value: ['FROM-DCMTK'] } };
+        mockedDcm2json.mockResolvedValue(ok({ data: fallbackData, source: 'xml' as const }));
+        const result = await dicom2json(garbagePath, { dcmtkFallback: true, charsetAssume: 'latin-1' });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.source).toBe('xml');
+            expect(result.value.data).toEqual(fallbackData);
+        }
+        expect(mockedDcm2json).toHaveBeenCalledWith(
+            garbagePath,
+            expect.objectContaining({
+                charsetAssume: 'latin-1',
+                timeoutMs: expect.any(Number) as number,
+            })
+        );
+    });
+
+    it('aggregates both errors when the fallback also fails', async () => {
+        mockedDcm2json.mockResolvedValue(err(new Error('binary exploded')));
+        const result = await dicom2json(garbagePath, { dcmtkFallback: true });
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.message).toContain('both engines failed');
+            expect(result.error.message).toContain('Failed to parse DICOM data');
+            expect(result.error.message).toContain('binary exploded');
+        }
+    });
+
+    it('skips the fallback when the timeout budget is exhausted', async () => {
+        const nowSpy = vi.spyOn(Date, 'now');
+        nowSpy.mockReturnValueOnce(0).mockReturnValueOnce(30_001);
+        const result = await dicom2json(garbagePath, { dcmtkFallback: true });
+        nowSpy.mockRestore();
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error.message).toContain('timeout budget exhausted');
+            expect(result.error.message).toContain('Failed to parse DICOM data');
+        }
+        expect(mockedDcm2json).not.toHaveBeenCalled();
+    });
+
+    it('also falls back on file read errors when fallback is enabled', async () => {
+        mockedDcm2json.mockResolvedValue(ok({ data: {}, source: 'xml' as const }));
+        const result = await dicom2json(join(tempDir, 'nope.dcm'), { dcmtkFallback: true });
+        expect(result.ok).toBe(true);
+        expect(mockedDcm2json).toHaveBeenCalledOnce();
+    });
+});
+
+describe('dicom2jsonFromBuffer', () => {
+    it('parses an in-memory buffer', () => {
+        const result = dicom2jsonFromBuffer(VALID_FILE);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.source).toBe('js');
+            expect(result.value.data['00100020']).toEqual({ vr: 'LO', Value: ['PAT001'] });
+        }
+    });
+
+    it('applies charset options', () => {
+        const file = p10(TS.explicitLE, [explicitEl('00100010', 'PN', evenPad('M\xfcller'))]);
+        const result = dicom2jsonFromBuffer(file, { charsetAssume: 'latin-1' });
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.value.data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'Müller' }] });
+    });
+
+    it('rejects unknown options', () => {
+        const result = dicom2jsonFromBuffer(VALID_FILE, { timeoutMs: 5 } as never);
+        expect(result.ok).toBe(false);
+    });
+
+    it('returns an error for a non-DICOM buffer', () => {
+        const result = dicom2jsonFromBuffer(Buffer.from('junk'.repeat(50)));
+        expect(result.ok).toBe(false);
+    });
+});

--- a/src/tools/dicom2json.test.ts
+++ b/src/tools/dicom2json.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
 import { ok, err } from '../types';
 import { TS, evenPad, explicitEl, p10 } from '../../test/helpers/p10';
 
@@ -20,15 +20,16 @@ let tempDir: string;
 let validPath: string;
 let garbagePath: string;
 
-beforeEach(async () => {
+beforeAll(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'dicom2json-test-'));
+    validPath = join(tempDir, 'valid.dcm');
+    garbagePath = join(tempDir, 'garbage.dcm');
+    await writeFile(validPath, VALID_FILE);
+    await writeFile(garbagePath, Buffer.from('not dicom '.repeat(20)));
+});
+
+beforeEach(() => {
     vi.clearAllMocks();
-    if (tempDir === undefined) {
-        tempDir = await mkdtemp(join(tmpdir(), 'dicom2json-test-'));
-        validPath = join(tempDir, 'valid.dcm');
-        garbagePath = join(tempDir, 'garbage.dcm');
-        await writeFile(validPath, VALID_FILE);
-        await writeFile(garbagePath, Buffer.from('not dicom '.repeat(20)));
-    }
 });
 
 afterAll(async () => {

--- a/src/tools/dicom2json.ts
+++ b/src/tools/dicom2json.ts
@@ -167,7 +167,7 @@ async function parseFromFile(inputPath: string, timeoutMs: number, options?: Dic
 function dicom2jsonFromBuffer(buffer: Uint8Array, options?: Dicom2jsonBufferOptions): Result<Dicom2jsonResult> {
     const validation = Dicom2jsonBufferOptionsSchema.safeParse(options);
     if (!validation.success) {
-        return err(createValidationError('dicom2json', validation.error));
+        return err(createValidationError('dicom2jsonFromBuffer', validation.error));
     }
     const parsed = parseDicomBuffer(buffer, options);
     if (!parsed.ok) {

--- a/src/tools/dicom2json.ts
+++ b/src/tools/dicom2json.ts
@@ -1,0 +1,180 @@
+/**
+ * Pure-JS DICOM to JSON conversion — no DCMTK binaries required.
+ *
+ * Parses DICOM Part-10 files directly in-process (via `dicom-parser`) and
+ * produces the same DICOM JSON Model shape as {@link dcm2json}, orders of
+ * magnitude faster: no process spawn, no XML intermediate, and bulk pixel
+ * data is never loaded.
+ *
+ * Differences from the dcm2json/dcm2xml output, by design:
+ * - File meta group 0002 elements are included, so
+ *   `DicomDataset.transferSyntaxUID` returns the actual transfer syntax.
+ * - Group length elements (gggg,0000) are always omitted.
+ *
+ * Set `dcmtkFallback: true` to retry with the deprecated {@link dcm2json}
+ * binary path when the JS parser fails (e.g. exotic files DCMTK tolerates).
+ *
+ * @module dicom2json
+ */
+
+import { readFile } from 'node:fs/promises';
+import { z } from 'zod';
+import type { Result } from '../types';
+import { ok, err } from '../types';
+import { DEFAULT_TIMEOUT_MS } from '../constants';
+import { createValidationError } from './_toolError';
+import { parseDicomBuffer } from './_p10ToJson';
+import { dcm2json } from './dcm2json';
+import type { DicomJsonModel } from './_xmlToJson';
+import type { ToolBaseOptions } from './_toolTypes';
+
+/** Indicates which engine produced the result. 'js' is the pure-JS parser; 'xml' and 'direct' come from the DCMTK fallback. */
+type Dicom2jsonSource = 'js' | 'xml' | 'direct';
+
+/** Options for {@link dicom2json}. */
+interface Dicom2jsonOptions extends ToolBaseOptions {
+    /** Assume the specified character set when SpecificCharacterSet (0008,0005) is absent. Accepts DICOM defined terms ('ISO_IR 100') or DCMTK-style aliases ('latin-1'). */
+    readonly charsetAssume?: string | undefined;
+    /** Charset to decode with when the file's specified character set is unsupported. `'latin-1'` recommended — maps every byte to a valid character. */
+    readonly charsetFallback?: string | undefined;
+    /** Retry with the deprecated dcm2json binary path when the JS parser fails. Defaults to false. */
+    readonly dcmtkFallback?: boolean | undefined;
+}
+
+/** Options for {@link dicom2jsonFromBuffer} (charset handling only). */
+type Dicom2jsonBufferOptions = Pick<Dicom2jsonOptions, 'charsetAssume' | 'charsetFallback'>;
+
+/** Result of a successful dicom2json conversion. */
+interface Dicom2jsonResult {
+    /** The DICOM JSON Model object. */
+    readonly data: DicomJsonModel;
+    /** Non-fatal parser warnings (empty for DCMTK fallback results). */
+    readonly warnings: readonly string[];
+    /** Which engine produced this result. */
+    readonly source: Dicom2jsonSource;
+}
+
+const Dicom2jsonOptionsSchema = z
+    .object({
+        timeoutMs: z.number().int().positive().optional(),
+        signal: z.instanceof(AbortSignal).optional(),
+        charsetAssume: z.string().min(1).optional(),
+        charsetFallback: z.string().min(1).optional(),
+        dcmtkFallback: z.boolean().optional(),
+    })
+    .strict()
+    .optional();
+
+const Dicom2jsonBufferOptionsSchema = z
+    .object({
+        charsetAssume: z.string().min(1).optional(),
+        charsetFallback: z.string().min(1).optional(),
+    })
+    .strict()
+    .optional();
+
+/** Reads a file with a timeout and optional external abort signal. */
+async function readFileBounded(inputPath: string, timeoutMs: number, signal?: AbortSignal): Promise<Result<Buffer>> {
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    const combined = signal !== undefined ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+    try {
+        return ok(await readFile(inputPath, { signal: combined }));
+    } catch (error: unknown) {
+        if (timeoutSignal.aborted) {
+            return err(new Error(`dicom2json: reading '${inputPath}' timed out after ${String(timeoutMs)}ms`));
+        }
+        if (signal?.aborted === true) {
+            return err(new Error(`dicom2json: aborted while reading '${inputPath}'`));
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        return err(new Error(`dicom2json: failed to read '${inputPath}': ${message}`));
+    }
+}
+
+/** Runs the DCMTK fallback with the remaining time budget, aggregating both errors on double failure. */
+async function runDcmtkFallback(inputPath: string, jsError: Error, remainingMs: number, options?: Dicom2jsonOptions): Promise<Result<Dicom2jsonResult>> {
+    if (remainingMs <= 0) {
+        return err(new Error(`dicom2json: JS parse failed and timeout budget exhausted (skipping DCMTK fallback) | js: ${jsError.message}`));
+    }
+    const fallback = await dcm2json(inputPath, {
+        timeoutMs: remainingMs,
+        signal: options?.signal,
+        charsetAssume: options?.charsetAssume,
+        charsetFallback: options?.charsetFallback,
+    });
+    if (!fallback.ok) {
+        return err(new Error(`dicom2json: both engines failed | js: ${jsError.message} | dcmtk: ${fallback.error.message}`));
+    }
+    return ok({ data: fallback.value.data, warnings: [], source: fallback.value.source });
+}
+
+/**
+ * Converts a DICOM file to the DICOM JSON Model using the pure-JS parser.
+ *
+ * @param inputPath - Path to the DICOM input file
+ * @param options - Conversion options
+ * @returns A Result containing the DICOM JSON Model with source discriminant
+ *
+ * @example
+ * ```ts
+ * const result = await dicom2json('/path/to/study.dcm');
+ * if (result.ok) {
+ *     console.log(result.value.source); // 'js'
+ *     console.log(result.value.data['00100010']); // Patient Name
+ * }
+ * ```
+ */
+async function dicom2json(inputPath: string, options?: Dicom2jsonOptions): Promise<Result<Dicom2jsonResult>> {
+    const validation = Dicom2jsonOptionsSchema.safeParse(options);
+    if (!validation.success) {
+        return err(createValidationError('dicom2json', validation.error));
+    }
+
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const startTime = Date.now();
+    const parsed = await parseFromFile(inputPath, timeoutMs, options);
+    if (parsed.ok) {
+        return parsed;
+    }
+    if (options?.dcmtkFallback === true) {
+        return runDcmtkFallback(inputPath, parsed.error, timeoutMs - (Date.now() - startTime), options);
+    }
+    return err(parsed.error);
+}
+
+/** Reads and parses a file with the JS engine. */
+async function parseFromFile(inputPath: string, timeoutMs: number, options?: Dicom2jsonOptions): Promise<Result<Dicom2jsonResult>> {
+    const fileResult = await readFileBounded(inputPath, timeoutMs, options?.signal);
+    if (!fileResult.ok) {
+        return err(fileResult.error);
+    }
+    const parsed = parseDicomBuffer(fileResult.value, { charsetAssume: options?.charsetAssume, charsetFallback: options?.charsetFallback });
+    if (!parsed.ok) {
+        return err(parsed.error);
+    }
+    return ok({ data: parsed.value.data, warnings: parsed.value.warnings, source: 'js' });
+}
+
+/**
+ * Converts an in-memory DICOM Part-10 buffer to the DICOM JSON Model.
+ *
+ * Synchronous — no file I/O, no timeout, no DCMTK fallback.
+ *
+ * @param buffer - The DICOM file bytes
+ * @param options - Charset handling options
+ * @returns A Result containing the DICOM JSON Model
+ */
+function dicom2jsonFromBuffer(buffer: Uint8Array, options?: Dicom2jsonBufferOptions): Result<Dicom2jsonResult> {
+    const validation = Dicom2jsonBufferOptionsSchema.safeParse(options);
+    if (!validation.success) {
+        return err(createValidationError('dicom2json', validation.error));
+    }
+    const parsed = parseDicomBuffer(buffer, options);
+    if (!parsed.ok) {
+        return err(parsed.error);
+    }
+    return ok({ data: parsed.value.data, warnings: parsed.value.warnings, source: 'js' });
+}
+
+export { dicom2json, dicom2jsonFromBuffer };
+export type { Dicom2jsonOptions, Dicom2jsonBufferOptions, Dicom2jsonResult, Dicom2jsonSource };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,6 +18,9 @@ export type { Dcm2xmlOptions, Dcm2xmlResult, Dcm2xmlCharsetValue } from './dcm2x
 export { dcm2json } from './dcm2json';
 export type { Dcm2jsonOptions, Dcm2jsonResult, Dcm2jsonSource, DicomJsonModel } from './dcm2json';
 
+export { dicom2json, dicom2jsonFromBuffer } from './dicom2json';
+export type { Dicom2jsonOptions, Dicom2jsonBufferOptions, Dicom2jsonResult, Dicom2jsonSource } from './dicom2json';
+
 export { dcmdump, DcmdumpFormat } from './dcmdump';
 export type { DcmdumpOptions, DcmdumpResult, DcmdumpFormatValue } from './dcmdump';
 

--- a/test/helpers/p10.ts
+++ b/test/helpers/p10.ts
@@ -1,0 +1,123 @@
+/**
+ * Test helper: builds synthetic DICOM Part-10 buffers for parser tests.
+ *
+ * Supports explicit/implicit VR, little/big endian, defined-length sequences,
+ * and encapsulated pixel data — enough surface to exercise _p10ToJson without
+ * real files or DCMTK binaries.
+ *
+ * @module test/helpers/p10
+ */
+
+/** Standard transfer syntax UIDs used by the builders. */
+const TS = {
+    implicitLE: '1.2.840.10008.1.2',
+    explicitLE: '1.2.840.10008.1.2.1',
+    explicitBE: '1.2.840.10008.1.2.2',
+    deflatedLE: '1.2.840.10008.1.2.1.99',
+    jpegBaseline: '1.2.840.10008.1.2.4.50',
+} as const;
+
+/** VRs encoded with the 12-byte (long) explicit form. */
+const LONG_FORM_VRS = new Set(['OB', 'OW', 'OF', 'OD', 'OL', 'OV', 'SQ', 'UC', 'UR', 'UT', 'UN', 'SV', 'UV']);
+
+/** Encodes a 'GGGGEEEE' tag. */
+function tagBytes(tag: string, bigEndian = false): Buffer {
+    const group = parseInt(tag.slice(0, 4), 16);
+    const element = parseInt(tag.slice(4, 8), 16);
+    const buf = Buffer.alloc(4);
+    if (bigEndian) {
+        buf.writeUInt16BE(group, 0);
+        buf.writeUInt16BE(element, 2);
+    } else {
+        buf.writeUInt16LE(group, 0);
+        buf.writeUInt16LE(element, 2);
+    }
+    return buf;
+}
+
+/** Pads a string value to even length. UI pads with NUL, text VRs with space. */
+function evenPad(value: string, padChar = ' '): Buffer {
+    const raw = Buffer.from(value, 'latin1');
+    if (raw.length % 2 === 0) return raw;
+    return Buffer.concat([raw, Buffer.from(padChar, 'latin1')]);
+}
+
+/** Encodes one explicit-VR element. */
+function explicitEl(tag: string, vr: string, value: Buffer, bigEndian = false): Buffer {
+    const head = tagBytes(tag, bigEndian);
+    const vrBytes = Buffer.from(vr, 'latin1');
+    if (LONG_FORM_VRS.has(vr)) {
+        const len = Buffer.alloc(6);
+        if (bigEndian) {
+            len.writeUInt32BE(value.length, 2);
+        } else {
+            len.writeUInt32LE(value.length, 2);
+        }
+        return Buffer.concat([head, vrBytes, len, value]);
+    }
+    const len = Buffer.alloc(2);
+    if (bigEndian) {
+        len.writeUInt16BE(value.length, 0);
+    } else {
+        len.writeUInt16LE(value.length, 0);
+    }
+    return Buffer.concat([head, vrBytes, len, value]);
+}
+
+/** Encodes one implicit-VR element (always little endian). */
+function implicitEl(tag: string, value: Buffer): Buffer {
+    const len = Buffer.alloc(4);
+    len.writeUInt32LE(value.length, 0);
+    return Buffer.concat([tagBytes(tag), len, value]);
+}
+
+/** Wraps item content in a defined-length item (FFFE,E000). */
+function item(content: Buffer, bigEndian = false): Buffer {
+    const head = tagBytes('FFFEE000', bigEndian);
+    const len = Buffer.alloc(4);
+    if (bigEndian) {
+        len.writeUInt32BE(content.length, 0);
+    } else {
+        len.writeUInt32LE(content.length, 0);
+    }
+    return Buffer.concat([head, len, content]);
+}
+
+/** Encodes a defined-length explicit-VR SQ element from item contents. */
+function sqExplicit(tag: string, itemContents: readonly Buffer[], bigEndian = false): Buffer {
+    const items = Buffer.concat(itemContents.map(c => item(c, bigEndian)));
+    return explicitEl(tag, 'SQ', items, bigEndian);
+}
+
+/** Encodes a defined-length implicit-VR SQ element. */
+function sqImplicit(tag: string, itemContents: readonly Buffer[]): Buffer {
+    const items = Buffer.concat(itemContents.map(c => item(c)));
+    return implicitEl(tag, items);
+}
+
+/** Encodes an encapsulated pixel-data element (undefined length, offset table + one fragment). */
+function encapsulatedPixelData(fragment: Buffer): Buffer {
+    const head = explicitEl('7FE00010', 'OB', Buffer.alloc(0)).subarray(0, 8);
+    const undefinedLen = Buffer.from([0xff, 0xff, 0xff, 0xff]);
+    const offsetTable = item(Buffer.alloc(0));
+    const frag = item(fragment);
+    const delimiter = Buffer.concat([tagBytes('FFFEE0DD'), Buffer.alloc(4)]);
+    return Buffer.concat([head, undefinedLen, offsetTable, frag, delimiter]);
+}
+
+/** Builds the file meta group (always explicit little endian). */
+function metaGroup(transferSyntaxUid: string): Buffer {
+    const tsEl = explicitEl('00020010', 'UI', evenPad(transferSyntaxUid, '\0'));
+    const sopClassEl = explicitEl('00020002', 'UI', evenPad('1.2.840.10008.5.1.4.1.1.7', '\0'));
+    const groupLen = Buffer.alloc(4);
+    groupLen.writeUInt32LE(sopClassEl.length + tsEl.length, 0);
+    const groupLenEl = explicitEl('00020000', 'UL', groupLen);
+    return Buffer.concat([groupLenEl, sopClassEl, tsEl]);
+}
+
+/** Builds a complete Part-10 file: preamble + DICM + meta + dataset elements. */
+function p10(transferSyntaxUid: string, datasetElements: readonly Buffer[]): Buffer {
+    return Buffer.concat([Buffer.alloc(128), Buffer.from('DICM', 'latin1'), metaGroup(transferSyntaxUid), ...datasetElements]);
+}
+
+export { TS, tagBytes, evenPad, explicitEl, implicitEl, item, sqExplicit, sqImplicit, encapsulatedPixelData, metaGroup, p10 };

--- a/test/integration/tools/dicom2json.integration.test.ts
+++ b/test/integration/tools/dicom2json.integration.test.ts
@@ -1,0 +1,177 @@
+import { readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { dcm2json, dicom2json } from '../../../src';
+import type { DicomJsonModel, DicomJsonElement } from '../../../src';
+import { dcmtkAvailable, SAMPLES } from '../helpers';
+
+const SAMPLES_ROOT = resolve(__dirname, '../../../dicomSamples');
+
+/** All good sample files (bad/ excluded — handled separately). */
+function listSampleFiles(): string[] {
+    const dirs = ['1010_brain_mr_12_jpg', 'other'];
+    const files: string[] = [];
+    for (const dir of dirs) {
+        for (const name of readdirSync(join(SAMPLES_ROOT, dir))) {
+            if (/\.dcm$/i.test(name)) {
+                files.push(join(SAMPLES_ROOT, dir, name));
+            }
+        }
+    }
+    return files;
+}
+
+/** True for private (odd-group) tags. */
+function isPrivateTag(tag: string): boolean {
+    return parseInt(tag.slice(0, 4), 16) % 2 === 1;
+}
+
+/** Relative-epsilon comparison for FL/FD precision differences between engines. */
+function closeEnough(a: unknown, b: unknown): boolean {
+    if (typeof a !== 'number' || typeof b !== 'number') return false;
+    if (a === b) return true;
+    const rel = Math.abs(a - b) / Math.max(Math.abs(a), Math.abs(b), 1e-30);
+    return rel < 1e-5;
+}
+
+/**
+ * Collects differences between the XML-path model and the JS model.
+ *
+ * Exclusions, both verified against dcmdump ground truth:
+ * - group 0002: deliberately included by the JS engine, omitted by dcm2xml
+ * - private (odd-group) tags: dcm2xml renumbers private blocks incorrectly;
+ *   the JS output preserves the file's actual tags
+ */
+function diffModel(xml: DicomJsonModel, js: DicomJsonModel, out: string[], path = ''): void {
+    const xmlTags = Object.keys(xml).filter(t => !isPrivateTag(t));
+    const jsTags = Object.keys(js).filter(t => !t.startsWith('0002') && !isPrivateTag(t));
+    for (const tag of xmlTags) {
+        const xmlEl = xml[tag];
+        const jsEl = js[tag];
+        if (xmlEl === undefined) continue;
+        if (jsEl === undefined) {
+            out.push(`${path}${tag}: missing in js`);
+            continue;
+        }
+        diffElement({ xmlEl, jsEl, label: `${path}${tag}` }, out);
+    }
+    for (const tag of jsTags) {
+        if (xml[tag] === undefined) out.push(`${path}${tag}: extra in js`);
+    }
+}
+
+/** An element pair under comparison, with its diagnostic path prefix. */
+interface ElementPair {
+    readonly xmlEl: DicomJsonElement;
+    readonly jsEl: DicomJsonElement;
+    readonly label: string;
+}
+
+/** Compares SQ item lists, recursing via diffModel. */
+function diffSequence(pair: ElementPair, out: string[]): void {
+    const xmlItems = (pair.xmlEl.Value ?? []) as readonly DicomJsonModel[];
+    const jsItems = (pair.jsEl.Value ?? []) as readonly DicomJsonModel[];
+    if (xmlItems.length !== jsItems.length) {
+        out.push(`${pair.label}: item count ${String(xmlItems.length)} != ${String(jsItems.length)}`);
+        return;
+    }
+    for (let i = 0; i < xmlItems.length; i++) {
+        const xmlItem = xmlItems[i];
+        const jsItem = jsItems[i];
+        if (xmlItem !== undefined && jsItem !== undefined) {
+            diffModel(xmlItem, jsItem, out, `${pair.label}[${String(i)}].`);
+        }
+    }
+}
+
+/** Compares leaf values with a numeric epsilon for FL/FD. */
+function diffValues(pair: ElementPair, out: string[]): void {
+    if (JSON.stringify(pair.xmlEl.Value) === JSON.stringify(pair.jsEl.Value)) return;
+    const xmlValues = pair.xmlEl.Value ?? [];
+    const jsValues = pair.jsEl.Value ?? [];
+    if (xmlValues.length === jsValues.length && xmlValues.every((v, i) => closeEnough(v, jsValues[i]))) return;
+    out.push(`${pair.label}: value mismatch ${JSON.stringify(pair.xmlEl.Value)} != ${JSON.stringify(pair.jsEl.Value)}`);
+}
+
+/** Compares one element pair, recursing into sequences. */
+function diffElement(pair: ElementPair, out: string[]): void {
+    if (pair.xmlEl.vr !== pair.jsEl.vr) {
+        out.push(`${pair.label}: vr ${pair.xmlEl.vr} != ${pair.jsEl.vr}`);
+        return;
+    }
+    if (pair.xmlEl.vr === 'SQ') {
+        diffSequence(pair, out);
+        return;
+    }
+    diffValues(pair, out);
+}
+
+describe('dicom2json integration', () => {
+    it('parses a standard MR file with the JS engine', async () => {
+        const result = await dicom2json(SAMPLES.MR_BRAIN);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.source).toBe('js');
+            expect(result.value.data['00100010']).toBeDefined();
+            // Improvement over the XML path: file meta group is present
+            expect(result.value.data['00020010']).toBeDefined();
+        }
+    });
+
+    it('returns an error for a non-existent file', async () => {
+        const result = await dicom2json('/nonexistent/path/file.dcm');
+        expect(result.ok).toBe(false);
+    });
+
+    it('fails gracefully (no throw) on bad sample files', async () => {
+        for (const bad of [SAMPLES.BAD_0002, SAMPLES.BAD_0003]) {
+            const result = await dicom2json(bad);
+            expect(typeof result.ok).toBe('boolean');
+        }
+    });
+});
+
+describe.skipIf(!dcmtkAvailable)('dicom2json differential vs DCMTK', () => {
+    it('agrees with the dcm2xml path on every good sample file', async () => {
+        const files = listSampleFiles();
+        expect(files.length).toBeGreaterThan(100);
+        const failures: string[] = [];
+        for (const file of files) {
+            const [xmlResult, jsResult] = await Promise.all([dcm2json(file, { timeoutMs: 60_000 }), dicom2json(file, { timeoutMs: 60_000 })]);
+            if (!xmlResult.ok) continue; // XML path unavailable for this file — nothing to compare against
+            if (!jsResult.ok) {
+                failures.push(`${file}: js parse failed: ${jsResult.error.message}`);
+                continue;
+            }
+            const diffs: string[] = [];
+            diffModel(xmlResult.value.data, jsResult.value.data, diffs);
+            if (diffs.length > 0) {
+                failures.push(`${file}:\n  ${diffs.slice(0, 10).join('\n  ')}`);
+            }
+        }
+        expect(failures, failures.join('\n')).toEqual([]);
+    }, 300_000);
+
+    it('is at least 5x faster than the XML path', async () => {
+        const files = listSampleFiles().slice(0, 30);
+
+        // Warm up both paths
+        await dicom2json(files[0] as string);
+        await dcm2json(files[0] as string);
+
+        const jsStart = performance.now();
+        for (const file of files) {
+            await dicom2json(file, { timeoutMs: 60_000 });
+        }
+        const jsMs = performance.now() - jsStart;
+
+        const xmlStart = performance.now();
+        for (const file of files) {
+            await dcm2json(file, { timeoutMs: 60_000 });
+        }
+        const xmlMs = performance.now() - xmlStart;
+
+        // Measured ~75x locally; 5x is a loose regression gate resilient to CI noise
+        expect(jsMs * 5).toBeLessThan(xmlMs);
+    }, 300_000);
+});


### PR DESCRIPTION
## Summary

Resolves #30 by pivoting rather than patching: instead of reordering the two DCMTK binary paths, DICOM→JSON parsing moves in-process.

- **New `dicom2json`** — pure-JS parser built on `dicom-parser` 1.8.21 (zero deps), producing the same DICOM JSON Model as `dcm2json`. **~75x faster** (1.4ms vs 104ms/file): no process spawn, no 3.2MB-XML intermediate, bulk pixel data never loaded. Plus sync in-memory `dicom2jsonFromBuffer`.
- **Native charset decoding** — all single-byte ISO_IR sets, UTF-8, GB18030/GBK, Shift_JIS, and ISO 2022 CJK code extensions (JP IR 13/87, KR IR 149, CN IR 58), validated against the PS3.5 Annex H/I/J examples.
- **`DicomInstance.open` / `DicomReceiver` / `PacsClient` default to the JS engine** with automatic DCMTK-binary fallback (`engine: 'dcmtk'` forces the old path). The #30 timeout pathology is structurally eliminated on the default path.
- **Legacy `dcm2json` fixed per #30 and deprecated**: fallback floor (`Math.max(1000, …)`) removed — the direct path runs with the real remaining budget, is skipped when exhausted, and both errors are aggregated on double failure.

## Bugs found along the way (verified against dcmdump ground truth)

- `xmlToJson` decoded empty `<Value number="1"/>` elements as the string `"1"` — fixed.
- **dcm2xml renumbers private tag blocks** (e.g. `(0019,1030)` → `(0019,0030)`), sometimes overwriting the private-creator slot. The JS engine preserves the file's actual tags — this alone is a data-fidelity win.
- Encapsulated pixel data with a wrong explicit VR is normalized to `OB` (matches DCMTK).

## Verification

- Differential integration suite: **tag-for-tag agreement with the dcm2xml path across all 198 sample files** (group 0002 and private tags excluded for the documented reasons above), plus a ≥5x perf regression gate.
- 82 new unit tests (charset fixtures from PS3.5 Annex H/I/J, synthetic P10 builder covering explicit/implicit VR, big endian, deflated, nested SQ, per-item charset override); 2107 total passing; coverage gate green.
- ADR 006 documents the decision and trade-offs.

## Known limitation

Explicit-VR `SV`/`UV`/`OV` files (rare, 2019-era VRs) fail to tokenize in `dicom-parser`; they fail gracefully and the automatic DCMTK fallback covers them in the high-level APIs. Implicit VR is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZAci6ihXZWzxhK19DoPz9