### PR TITLE
ci: bump actions to Node 24 runtimes (checkout v7, setup-node v6, pnpm v6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         name: Lint & Typecheck
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: pnpm/action-setup@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: pnpm
@@ -31,7 +31,7 @@ jobs:
         container:
             image: michaelleehobbs/nodejs-dcmtk:dcmtk-3.7.0-nodejs-24.12.0-alpine3.23
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - run: corepack enable && corepack prepare pnpm@10 --activate
             - run: pnpm install --frozen-lockfile
             - run: pnpm run test:all
@@ -41,9 +41,9 @@ jobs:
         runs-on: ubuntu-latest
         needs: [lint-and-typecheck, test]
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: pnpm/action-setup@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: pnpm
@@ -55,9 +55,9 @@ jobs:
         name: Security Audit
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: pnpm/action-setup@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: pnpm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,9 +14,9 @@ jobs:
         name: Publish to npm
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v7
+            - uses: pnpm/action-setup@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: 24
                   cache: pnpm


### PR DESCRIPTION
GitHub deprecated Node 20 action runtimes (2025-09-19 changelog); the
v4 actions were being force-run on Node 24 with warnings. Same versions
pino-cloudwatch-ts runs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012ZAci6ihXZWzxhK19DoPz9
