### PR TITLE
fix(tools): detect mislabeled UTF-8 in dicom2json, surface parser warnings on DicomInstance (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **`dicom2json`: UTF-8 mislabel detection**
+  ([#34](https://github.com/MichaelLeeHobbs/dcmtk.js/issues/34)). Files whose text bytes are
+  valid multi-byte UTF-8 while the resolved character set is a single-byte repertoire (or the
+  ASCII default when SpecificCharacterSet is absent) previously decoded silently as mojibake —
+  where `dcm2json` rejected them with exit 80. The JS engine now pushes a
+  `possible UTF-8 mislabel: <tag>` warning for each affected tag, and the new
+  `utf8MislabelPromote: true` option decodes those values as UTF-8 instead of the declared
+  charset. Available on `dicom2json`, `dicom2jsonFromBuffer`, `DicomInstance.open`
+  (`DicomOpenOptions`), and `DicomReceiver`'s `instanceOpenOptions`.
+- **`DicomInstance.warnings`** ([#34](https://github.com/MichaelLeeHobbs/dcmtk.js/issues/34)).
+  Parser warnings from the JS engine (including mislabel warnings) are now surfaced on the
+  instance instead of being dropped, and are preserved across fluent modifications. Empty for
+  `engine: 'dcmtk'` and `fromDataset()`. `DicomReceiver` consumers can read them in
+  `INSTANCE_RECEIVED` handlers via `data.instance.warnings`.
+
+### Fixed
+
+- `DicomReceiver`'s `instanceOpenOptions` validation rejected the documented `engine` option
+  (`.strict()` schema was missing the key added in rc.2).
+
 ## [1.0.0-rc.2] - 2026-07-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -468,6 +468,7 @@ inst.patientName; // string (convenience getter)
 inst.dataset; // DicomDataset
 inst.filePath; // string | undefined
 inst.changes; // ChangeSet
+inst.warnings; // readonly string[] (parser warnings, e.g. possible UTF-8 mislabel)
 
 const modified = inst.setPatientName('DOE^JOHN').erasePrivateTags();
 const updated = inst.withChanges(changes); // merge external ChangeSet

--- a/docs/dicom-data-layer.md
+++ b/docs/dicom-data-layer.md
@@ -166,16 +166,17 @@ const inst = instResult.value;
 
 ### Properties
 
-| Property            | Type                  | Description                        |
-| ------------------- | --------------------- | ---------------------------------- |
-| `dataset`           | `DicomDataset`        | Immutable parsed dataset           |
-| `filePath`          | `string \| undefined` | File path (undefined if in-memory) |
-| `changes`           | `ChangeSet`           | Accumulated pending changes        |
-| `hasUnsavedChanges` | `boolean`             | Whether there are pending changes  |
-| `patientName`       | `string`              | Convenience getter for (0010,0010) |
-| `patientID`         | `string`              | Convenience getter for (0010,0020) |
-| `modality`          | `string`              | Convenience getter for (0008,0060) |
-| `studyDate`         | `string`              | Convenience getter for (0008,0020) |
+| Property            | Type                  | Description                                                                                                                     |
+| ------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `dataset`           | `DicomDataset`        | Immutable parsed dataset                                                                                                        |
+| `filePath`          | `string \| undefined` | File path (undefined if in-memory)                                                                                              |
+| `changes`           | `ChangeSet`           | Accumulated pending changes                                                                                                     |
+| `hasUnsavedChanges` | `boolean`             | Whether there are pending changes                                                                                               |
+| `warnings`          | `readonly string[]`   | Non-fatal parser warnings from opening (e.g. `possible UTF-8 mislabel: <tag>`); empty for `engine: 'dcmtk'` and `fromDataset()` |
+| `patientName`       | `string`              | Convenience getter for (0010,0010)                                                                                              |
+| `patientID`         | `string`              | Convenience getter for (0010,0020)                                                                                              |
+| `modality`          | `string`              | Convenience getter for (0008,0060)                                                                                              |
+| `studyDate`         | `string`              | Convenience getter for (0008,0020)                                                                                              |
 
 ### Modifying Tags (Fluent API)
 

--- a/docs/tools/data-metadata.md
+++ b/docs/tools/data-metadata.md
@@ -48,16 +48,26 @@ if (result.ok) {
 const bufferResult = dicom2jsonFromBuffer(buffer, { charsetAssume: 'latin-1' });
 ```
 
-| Option            | Type      | Default | Description                                                                                     |
-| ----------------- | --------- | ------- | ----------------------------------------------------------------------------------------------- |
-| `charsetAssume`   | `string`  | —       | Charset to assume when SpecificCharacterSet (0008,0005) is absent (`'ISO_IR 100'`, `'latin-1'`) |
-| `charsetFallback` | `string`  | —       | Charset to decode with when the file's charset is unsupported (`'latin-1'` recommended)         |
-| `dcmtkFallback`   | `boolean` | `false` | Retry with the deprecated dcm2json binary path when the JS parser fails                         |
+| Option                | Type      | Default | Description                                                                                     |
+| --------------------- | --------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `charsetAssume`       | `string`  | —       | Charset to assume when SpecificCharacterSet (0008,0005) is absent (`'ISO_IR 100'`, `'latin-1'`) |
+| `charsetFallback`     | `string`  | —       | Charset to decode with when the file's charset is unsupported (`'latin-1'` recommended)         |
+| `utf8MislabelPromote` | `boolean` | `false` | Decode values detected as mislabeled UTF-8 as UTF-8 instead of the declared charset             |
+| `dcmtkFallback`       | `boolean` | `false` | Retry with the deprecated dcm2json binary path when the JS parser fails                         |
 
 **Result:** `{ data: DicomJsonModel, warnings: readonly string[], source: 'js' | 'xml' | 'direct' }`
 
 Character sets: all single-byte ISO_IR sets, UTF-8, GB18030/GBK, Shift_JIS, and the common
 ISO 2022 code extensions (Japanese IR 13/87, Korean IR 149, Chinese IR 58) are decoded natively.
+
+**UTF-8 mislabel detection:** when the resolved charset is single-byte (or the ASCII default
+because 0008,0005 is absent) and a value's raw bytes contain a byte ≥ 0x80 while forming valid
+UTF-8, the value is near-certainly mislabeled UTF-8 — the dcm2json binary rejected such files
+with exit 80; the JS decoders cannot fail on byte content. The parser pushes a
+`possible UTF-8 mislabel: <tag>` warning (one per distinct tag) either way; with
+`utf8MislabelPromote: true` those values are decoded as UTF-8 instead of producing mojibake.
+The same options are accepted by `DicomInstance.open` and `DicomReceiver`'s
+`instanceOpenOptions`, and the warnings surface on `DicomInstance.warnings`.
 
 Differences from the dcm2json binary path (both verified against `dcmdump` ground truth):
 

--- a/src/dicom/DicomInstance.test.ts
+++ b/src/dicom/DicomInstance.test.ts
@@ -138,6 +138,44 @@ describe('DicomInstance', () => {
             );
             expect(mockedDicom2json).not.toHaveBeenCalled();
         });
+
+        it('surfaces parser warnings on the instance (#34)', async () => {
+            mockedDicom2json.mockResolvedValue({
+                ok: true,
+                value: { data: SAMPLE_JSON, warnings: ['possible UTF-8 mislabel: 00100010'], source: 'js' as const },
+            });
+            const result = await DicomInstance.open('/path/to/test.dcm');
+            expect(result.ok).toBe(true);
+            if (result.ok) expect(result.value.warnings).toEqual(['possible UTF-8 mislabel: 00100010']);
+        });
+
+        it('preserves warnings across fluent modifications', async () => {
+            mockedDicom2json.mockResolvedValue({
+                ok: true,
+                value: { data: SAMPLE_JSON, warnings: ['w1'], source: 'js' as const },
+            });
+            const result = await DicomInstance.open('/path/to/test.dcm');
+            expect(result.ok).toBe(true);
+            if (!result.ok) return;
+            const modified = result.value.setPatientName('DOE^JOHN').withMetadata('k', 'v');
+            expect(modified.warnings).toEqual(['w1']);
+        });
+
+        it('passes utf8MislabelPromote to dicom2json', async () => {
+            await DicomInstance.open('/path/to/test.dcm', { utf8MislabelPromote: true });
+            expect(mockedDicom2json).toHaveBeenCalledWith(
+                '/path/to/test.dcm',
+                expect.objectContaining({
+                    utf8MislabelPromote: true,
+                })
+            );
+        });
+
+        it("reports empty warnings for engine 'dcmtk'", async () => {
+            const result = await DicomInstance.open('/path/to/test.dcm', { engine: 'dcmtk' });
+            expect(result.ok).toBe(true);
+            if (result.ok) expect(result.value.warnings).toEqual([]);
+        });
     });
 
     describe('fromDataset()', () => {

--- a/src/dicom/DicomInstance.ts
+++ b/src/dicom/DicomInstance.ts
@@ -24,22 +24,55 @@ import { applyModifications, copyFileSafe, statFileSize, unlinkFile } from './_f
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** The JSON Model plus non-fatal parser warnings from reading a file. */
+interface ReadDicomJsonResult {
+    readonly data: DicomJsonModel;
+    readonly warnings: readonly string[];
+}
+
+/** Shared per-call options for both engines. */
+interface SharedReadOptions {
+    readonly timeoutMs: number;
+    readonly signal?: AbortSignal | undefined;
+    readonly charsetAssume?: string | undefined;
+    readonly charsetFallback?: string | undefined;
+}
+
+/** Reads via the deprecated dcm2json binary path (no warnings channel). */
+async function readViaDcmtk(path: string, shared: SharedReadOptions): Promise<Result<ReadDicomJsonResult>> {
+    const result = await dcm2json(path, shared);
+    if (!result.ok) return err(result.error);
+    return ok({ data: result.value.data, warnings: [] });
+}
+
 /** Reads a DICOM file into the JSON Model using the engine selected in the options. */
-async function readDicomJson(path: string, options?: DicomOpenOptions): Promise<Result<DicomJsonModel>> {
-    const shared = {
+async function readDicomJson(path: string, options?: DicomOpenOptions): Promise<Result<ReadDicomJsonResult>> {
+    const shared: SharedReadOptions = {
         timeoutMs: options?.timeoutMs ?? DEFAULT_TIMEOUT_MS,
         signal: options?.signal,
         charsetAssume: options?.charsetAssume,
         charsetFallback: options?.charsetFallback,
     };
-    const result = options?.engine === 'dcmtk' ? await dcm2json(path, shared) : await dicom2json(path, { ...shared, dcmtkFallback: true });
+    if (options?.engine === 'dcmtk') {
+        return readViaDcmtk(path, shared);
+    }
+    const result = await dicom2json(path, { ...shared, utf8MislabelPromote: options?.utf8MislabelPromote, dcmtkFallback: true });
     if (!result.ok) return err(result.error);
-    return ok(result.value.data);
+    return ok({ data: result.value.data, warnings: result.value.warnings });
 }
 
 // ---------------------------------------------------------------------------
 // DicomInstance class
 // ---------------------------------------------------------------------------
+
+/** Complete internal state of a DicomInstance. */
+interface DicomInstanceState {
+    readonly dataset: DicomDataset;
+    readonly changes: ChangeSet;
+    readonly filePath: DicomFilePath | undefined;
+    readonly metadata: ReadonlyMap<string, unknown>;
+    readonly warnings: readonly string[];
+}
 
 /**
  * Unified DICOM object composing dataset, change tracking, file path, and metadata.
@@ -64,12 +97,26 @@ class DicomInstance {
     private readonly changeSet: ChangeSet;
     private readonly filepath: DicomFilePath | undefined;
     private readonly meta: ReadonlyMap<string, unknown>;
+    private readonly warningList: readonly string[];
 
-    private constructor(dataset: DicomDataset, changes: ChangeSet, filePath: DicomFilePath | undefined, metadata: ReadonlyMap<string, unknown>) {
-        this.dicomDataset = dataset;
-        this.changeSet = changes;
-        this.filepath = filePath;
-        this.meta = metadata;
+    private constructor(state: DicomInstanceState) {
+        this.dicomDataset = state.dataset;
+        this.changeSet = state.changes;
+        this.filepath = state.filePath;
+        this.meta = state.metadata;
+        this.warningList = state.warnings;
+    }
+
+    /** Creates a copy with the given fields replaced. */
+    private derive(overrides: Partial<DicomInstanceState>): DicomInstance {
+        return new DicomInstance({
+            dataset: this.dicomDataset,
+            changes: this.changeSet,
+            filePath: this.filepath,
+            metadata: this.meta,
+            warnings: this.warningList,
+            ...overrides,
+        });
     }
 
     // -----------------------------------------------------------------------
@@ -90,10 +137,18 @@ class DicomInstance {
         const jsonResult = await readDicomJson(path, options);
         if (!jsonResult.ok) return err(jsonResult.error);
 
-        const datasetResult = DicomDataset.fromJson(jsonResult.value);
+        const datasetResult = DicomDataset.fromJson(jsonResult.value.data);
         if (!datasetResult.ok) return err(datasetResult.error);
 
-        return ok(new DicomInstance(datasetResult.value, ChangeSet.empty(), filePathResult.value, new Map()));
+        return ok(
+            new DicomInstance({
+                dataset: datasetResult.value,
+                changes: ChangeSet.empty(),
+                filePath: filePathResult.value,
+                metadata: new Map(),
+                warnings: jsonResult.value.warnings,
+            })
+        );
     }
 
     /**
@@ -110,7 +165,7 @@ class DicomInstance {
             if (!fpResult.ok) return err(fpResult.error);
             fp = fpResult.value;
         }
-        return ok(new DicomInstance(dataset, ChangeSet.empty(), fp, new Map()));
+        return ok(new DicomInstance({ dataset, changes: ChangeSet.empty(), filePath: fp, metadata: new Map(), warnings: [] }));
     }
 
     // -----------------------------------------------------------------------
@@ -135,6 +190,16 @@ class DicomInstance {
     /** The file path, or undefined if this instance has no associated file. */
     get filePath(): string | undefined {
         return this.filepath;
+    }
+
+    /**
+     * Non-fatal parser warnings from opening the file (e.g. `possible UTF-8 mislabel: <tag>`).
+     *
+     * Empty for instances created via {@link DicomInstance.fromDataset} or opened with
+     * `engine: 'dcmtk'`. Preserved across fluent modifications.
+     */
+    get warnings(): readonly string[] {
+        return this.warningList;
     }
 
     /** Patient's Name (0010,0010). */
@@ -231,7 +296,7 @@ class DicomInstance {
      * @param value - The new value
      */
     setTag(path: string, value: string): DicomInstance {
-        return new DicomInstance(this.dicomDataset, this.changeSet.setTag(path, value), this.filepath, this.meta);
+        return this.derive({ changes: this.changeSet.setTag(path, value) });
     }
 
     /**
@@ -240,12 +305,12 @@ class DicomInstance {
      * @param path - The DICOM tag path to erase
      */
     eraseTag(path: string): DicomInstance {
-        return new DicomInstance(this.dicomDataset, this.changeSet.eraseTag(path), this.filepath, this.meta);
+        return this.derive({ changes: this.changeSet.eraseTag(path) });
     }
 
     /** Erases all private tags, returning a new DicomInstance. */
     erasePrivateTags(): DicomInstance {
-        return new DicomInstance(this.dicomDataset, this.changeSet.erasePrivateTags(), this.filepath, this.meta);
+        return this.derive({ changes: this.changeSet.erasePrivateTags() });
     }
 
     /** Sets Patient's Name (0010,0010). */
@@ -309,7 +374,7 @@ class DicomInstance {
      * @param entries - A record of tag path → value pairs
      */
     setBatch(entries: Readonly<Record<string, string>>): DicomInstance {
-        return new DicomInstance(this.dicomDataset, this.changeSet.setBatch(entries), this.filepath, this.meta);
+        return this.derive({ changes: this.changeSet.setBatch(entries) });
     }
 
     /**
@@ -319,7 +384,7 @@ class DicomInstance {
      * @returns A new DicomInstance with accumulated changes
      */
     withChanges(changes: ChangeSet): DicomInstance {
-        return new DicomInstance(this.dicomDataset, this.changeSet.merge(changes), this.filepath, this.meta);
+        return this.derive({ changes: this.changeSet.merge(changes) });
     }
 
     /**
@@ -334,7 +399,7 @@ class DicomInstance {
     withFilePath(newPath: string): DicomInstance {
         const result = createDicomFilePath(newPath);
         if (!result.ok) throw result.error;
-        return new DicomInstance(this.dicomDataset, this.changeSet, result.value, this.meta);
+        return this.derive({ filePath: result.value });
     }
 
     // -----------------------------------------------------------------------
@@ -379,7 +444,7 @@ class DicomInstance {
             }
         }
 
-        return ok(new DicomInstance(this.dicomDataset, ChangeSet.empty(), outPathResult.value, this.meta));
+        return ok(this.derive({ changes: ChangeSet.empty(), filePath: outPathResult.value }));
     }
 
     /**
@@ -418,7 +483,7 @@ class DicomInstance {
     withMetadata(key: string, value: unknown): DicomInstance {
         const newMeta = new Map(this.meta);
         newMeta.set(key, value);
-        return new DicomInstance(this.dicomDataset, this.changeSet, this.filepath, newMeta);
+        return this.derive({ metadata: newMeta });
     }
 
     /**

--- a/src/dicom/_fileHelpers.ts
+++ b/src/dicom/_fileHelpers.ts
@@ -30,6 +30,12 @@ interface DicomOpenOptions extends FileIOOptions {
     /** Fallback charset to decode with when the file's character set is unsupported or conversion fails. `'latin-1'` is recommended — it maps every byte 0x00-0xFF to a valid character, so decoding never fails. */
     readonly charsetFallback?: string | undefined;
     /**
+     * Decode values detected as mislabeled UTF-8 (high bytes forming valid UTF-8 under a single-byte declared charset)
+     * as UTF-8 instead of the declared charset. A `possible UTF-8 mislabel` warning is surfaced either way via
+     * `DicomInstance.warnings`. JS engine only. Defaults to false.
+     */
+    readonly utf8MislabelPromote?: boolean | undefined;
+    /**
      * Parse engine. `'js'` (default) parses in-process via {@link dicom2json}
      * and automatically falls back to the DCMTK binaries when the JS parser
      * fails; `'dcmtk'` uses the deprecated dcm2json binary path exclusively.

--- a/src/servers/DicomReceiver.ts
+++ b/src/servers/DicomReceiver.ts
@@ -259,6 +259,8 @@ const DicomReceiverOptionsSchema = z
                 signal: z.instanceof(AbortSignal).optional(),
                 charsetAssume: z.string().min(1).optional(),
                 charsetFallback: z.string().min(1).optional(),
+                utf8MislabelPromote: z.boolean().optional(),
+                engine: z.enum(['js', 'dcmtk']).optional(),
             })
             .strict()
             .optional(),

--- a/src/tools/_charset.test.ts
+++ b/src/tools/_charset.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveCharsetContext, decodeDicomText, normalizeCharsetName, DEFAULT_CONTEXT } from './_charset';
+import { resolveCharsetContext, decodeDicomText, decodeUtf8, isProbableUtf8Mislabel, normalizeCharsetName, DEFAULT_CONTEXT } from './_charset';
 import type { CharsetContext } from './_charset';
 
 /** Resolves a context or fails the test. */
@@ -74,6 +74,48 @@ describe('resolveCharsetContext', () => {
         const result = resolveCharsetContext('ISO_IR 999', undefined, 'also-bad');
         expect(result.ok).toBe(false);
         if (!result.ok) expect(result.error.message).toContain('also-bad');
+    });
+});
+
+describe('CharsetContext.singleByte', () => {
+    it('is true for the ASCII default and Latin charsets', () => {
+        expect(DEFAULT_CONTEXT.singleByte).toBe(true);
+        expect(ctx(undefined).singleByte).toBe(true);
+        expect(ctx('ISO_IR 100').singleByte).toBe(true);
+        expect(ctx('ISO_IR 144').singleByte).toBe(true);
+        expect(ctx('ISO_IR 166').singleByte).toBe(true);
+    });
+
+    it('is false for multi-byte and ISO 2022 charsets', () => {
+        expect(ctx('ISO_IR 192').singleByte).toBe(false);
+        expect(ctx('GB18030').singleByte).toBe(false);
+        expect(ctx('ISO_IR 13').singleByte).toBe(false);
+        expect(ctx('ISO 2022 IR 6\\ISO 2022 IR 87').singleByte).toBe(false);
+        expect(ctx('ISO 2022 IR 149').singleByte).toBe(false);
+    });
+});
+
+describe('isProbableUtf8Mislabel', () => {
+    it('returns false for pure ASCII and empty input', () => {
+        expect(isProbableUtf8Mislabel(Buffer.from('Smith^John', 'latin1'))).toBe(false);
+        expect(isProbableUtf8Mislabel(Buffer.alloc(0))).toBe(false);
+    });
+
+    it('returns false for Latin-1 high bytes that are not valid UTF-8', () => {
+        expect(isProbableUtf8Mislabel(Buffer.from('M\xfcller^J\xf6rg', 'latin1'))).toBe(false);
+        expect(isProbableUtf8Mislabel(Buffer.from([0x80]))).toBe(false);
+        expect(isProbableUtf8Mislabel(Buffer.from([0xc3]))).toBe(false);
+    });
+
+    it('returns true for UTF-8 bytes with multi-byte sequences', () => {
+        expect(isProbableUtf8Mislabel(Buffer.from('Müller^José', 'utf-8'))).toBe(true);
+        expect(isProbableUtf8Mislabel(Buffer.from('王^小东', 'utf-8'))).toBe(true);
+    });
+});
+
+describe('decodeUtf8', () => {
+    it('decodes UTF-8 bytes', () => {
+        expect(decodeUtf8(Buffer.from('Müller^José', 'utf-8'))).toBe('Müller^José');
     });
 });
 

--- a/src/tools/_charset.ts
+++ b/src/tools/_charset.ts
@@ -137,6 +137,29 @@ const CHARSET_ALIASES: Readonly<Record<string, string>> = {
     gbk: 'GBK',
 };
 
+/**
+ * WHATWG labels that decode one byte per character. UTF-8 mislabel detection
+ * only applies under these (plus latin1/ASCII): a multi-byte charset can
+ * legitimately contain byte runs that also form valid UTF-8.
+ */
+const SINGLE_BYTE_LABELS: ReadonlySet<string> = new Set([
+    'iso-8859-2',
+    'iso-8859-3',
+    'iso-8859-4',
+    'iso-8859-5',
+    'iso-8859-6',
+    'iso-8859-7',
+    'iso-8859-8',
+    'iso-8859-9',
+    'iso-8859-15',
+    'windows-874',
+]);
+
+/** True when the decoder maps exactly one byte to one character. */
+function isSingleByteDecoder(decoder: SegmentDecoder): boolean {
+    return decoder.kind === 'latin1' || (decoder.kind === 'label' && SINGLE_BYTE_LABELS.has(decoder.label));
+}
+
 /** Cache of TextDecoder instances by label ('' = construction failed). */
 const decoderCache = new Map<string, TextDecoder | undefined>();
 
@@ -247,10 +270,12 @@ interface CharsetContext {
     readonly iso2022: boolean;
     /** Decoder for non-2022 charsets, or the initial decoder for ISO 2022. */
     readonly initial: SegmentDecoder;
+    /** Whether the context is a single-byte repertoire (UTF-8 mislabel detection applies). */
+    readonly singleByte: boolean;
 }
 
 /** The default context (ISO_IR 6 / ASCII). */
-const DEFAULT_CONTEXT: CharsetContext = { terms: ['ISO_IR 6'], iso2022: false, initial: LATIN1 };
+const DEFAULT_CONTEXT: CharsetContext = { terms: ['ISO_IR 6'], iso2022: false, initial: LATIN1, singleByte: true };
 
 /** Normalizes a user-supplied charset name (alias or defined term) to a defined term, or undefined. */
 function normalizeCharsetName(input: string): string | undefined {
@@ -267,7 +292,7 @@ function buildContext(terms: readonly string[]): CharsetContext | undefined {
     const first = terms[0] ?? 'ISO_IR 6';
     const initial = iso2022 ? ISO2022_INITIAL[first] : CHARSET_DECODERS[first];
     if (initial === undefined) return undefined;
-    return { terms, iso2022, initial };
+    return { terms, iso2022, initial, singleByte: !iso2022 && isSingleByteDecoder(initial) };
 }
 
 /** Parses raw SpecificCharacterSet values into normalized terms. An empty first value means the default repertoire. */
@@ -331,5 +356,49 @@ function decodeDicomText(bytes: Uint8Array, context: CharsetContext): string {
     return decodeSegment(bytes, context.initial);
 }
 
-export { resolveCharsetContext, decodeDicomText, normalizeCharsetName, DEFAULT_CONTEXT };
+/** Strict UTF-8 decoder used only for mislabel detection (throws on invalid sequences). */
+let strictUtf8: TextDecoder | undefined;
+
+/**
+ * Detects a near-certain UTF-8 mislabel: the bytes contain at least one byte
+ * >= 0x80 and the whole run is valid UTF-8. In valid UTF-8 every byte >= 0x80
+ * belongs to a multi-byte sequence, so both conditions together imply at least
+ * one multi-byte character — under a single-byte charset context that text is
+ * almost certainly UTF-8 with a wrong or absent SpecificCharacterSet.
+ *
+ * @param bytes - The raw value bytes
+ * @returns True when the bytes look like mislabeled UTF-8
+ */
+function isProbableUtf8Mislabel(bytes: Uint8Array): boolean {
+    let hasHighByte = false;
+    for (const byte of bytes) {
+        if (byte >= 0x80) {
+            hasHighByte = true;
+            break;
+        }
+    }
+    if (!hasHighByte) return false;
+    strictUtf8 ??= new TextDecoder('utf-8', { fatal: true });
+    try {
+        strictUtf8.decode(bytes);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+/** UTF-8 decoder for promoted mislabeled values. */
+const UTF8_DECODER: SegmentDecoder = label('utf-8');
+
+/**
+ * Decodes bytes as UTF-8 (used when promoting a detected mislabel).
+ *
+ * @param bytes - The raw value bytes
+ * @returns The decoded string
+ */
+function decodeUtf8(bytes: Uint8Array): string {
+    return decodeSegment(bytes, UTF8_DECODER);
+}
+
+export { resolveCharsetContext, decodeDicomText, normalizeCharsetName, isProbableUtf8Mislabel, decodeUtf8, DEFAULT_CONTEXT };
 export type { CharsetContext };

--- a/src/tools/_p10ToJson.test.ts
+++ b/src/tools/_p10ToJson.test.ts
@@ -278,6 +278,77 @@ describe('parseDicomBuffer — charset integration', () => {
     });
 });
 
+describe('parseDicomBuffer — UTF-8 mislabel detection (#34)', () => {
+    const utf8Name = evenPad(Buffer.from('Müller^José', 'utf-8').toString('latin1'));
+
+    it('warns when UTF-8 bytes appear under the ASCII default (no 0008,0005)', () => {
+        const result = parseDicomBuffer(p10(TS.explicitLE, [explicitEl('00100010', 'PN', utf8Name)]));
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.value.data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'MÃ¼ller^JosÃ©' }] });
+        expect(result.value.warnings).toContain("possible UTF-8 mislabel: 00100010 (decoded as 'ISO_IR 6')");
+    });
+
+    it('warns when UTF-8 bytes appear under a declared single-byte charset', () => {
+        const result = parseDicomBuffer(p10(TS.explicitLE, [explicitEl('00080005', 'CS', evenPad('ISO_IR 100')), explicitEl('00100010', 'PN', utf8Name)]));
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.value.warnings).toContain("possible UTF-8 mislabel: 00100010 (decoded as 'ISO_IR 100')");
+    });
+
+    it('decodes as UTF-8 when utf8MislabelPromote is set, still warning', () => {
+        const result = parseDicomBuffer(p10(TS.explicitLE, [explicitEl('00100010', 'PN', utf8Name)]), { utf8MislabelPromote: true });
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.value.data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'Müller^José' }] });
+        expect(result.value.warnings).toContain('possible UTF-8 mislabel: 00100010 (decoded as UTF-8)');
+    });
+
+    it('does not warn for correctly-labeled UTF-8 (ISO_IR 192)', () => {
+        const result = parseDicomBuffer(p10(TS.explicitLE, [explicitEl('00080005', 'CS', evenPad('ISO_IR 192')), explicitEl('00100010', 'PN', utf8Name)]));
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.value.data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'Müller^José' }] });
+        expect(result.value.warnings).toHaveLength(0);
+    });
+
+    it('does not warn for genuine Latin-1 high bytes (invalid as UTF-8)', () => {
+        const result = parseDicomBuffer(
+            p10(TS.explicitLE, [explicitEl('00080005', 'CS', evenPad('ISO_IR 100')), explicitEl('00100010', 'PN', evenPad('M\xfcller'))])
+        );
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.value.data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'Müller' }] });
+        expect(result.value.warnings).toHaveLength(0);
+    });
+
+    it('applies detection to charset-sensitive VRs and warns once per tag', () => {
+        const utf8Lo = evenPad(Buffer.from('José', 'utf-8').toString('latin1'));
+        const itemContent = Buffer.concat([explicitEl('00081090', 'LO', utf8Lo)]);
+        const result = parseDicomBuffer(
+            p10(TS.explicitLE, [
+                explicitEl('00081090', 'LO', utf8Lo),
+                sqExplicit('00081140', [itemContent, itemContent]),
+                explicitEl('00100010', 'PN', utf8Name),
+            ])
+        );
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        const mislabels = result.value.warnings.filter(w => w.includes('mislabel'));
+        expect(mislabels).toHaveLength(2);
+        expect(mislabels.some(w => w.includes('00081090'))).toBe(true);
+        expect(mislabels.some(w => w.includes('00100010'))).toBe(true);
+    });
+
+    it('does not apply detection to non-charset VRs', () => {
+        const utf8Cs = evenPad(Buffer.from('Aé', 'utf-8').toString('latin1'));
+        const result = parseDicomBuffer(p10(TS.explicitLE, [explicitEl('00080060', 'CS', utf8Cs)]));
+        expect(result.ok).toBe(true);
+        if (!result.ok) return;
+        expect(result.value.warnings).toHaveLength(0);
+    });
+});
+
 describe('parseDicomBuffer — structure and errors', () => {
     it('includes file meta group 0002 and omits group lengths', () => {
         const data = parse(p10(TS.explicitLE, [explicitEl('00100020', 'LO', evenPad('PAT001'))]));

--- a/src/tools/_p10ToJson.ts
+++ b/src/tools/_p10ToJson.ts
@@ -23,7 +23,7 @@ import { stderr } from 'stderr-lib';
 import type { Result } from '../types';
 import { ok, err } from '../types';
 import { lookupTag } from '../dicom/dictionary';
-import { decodeDicomText, resolveCharsetContext } from './_charset';
+import { decodeDicomText, decodeUtf8, isProbableUtf8Mislabel, resolveCharsetContext } from './_charset';
 import type { CharsetContext } from './_charset';
 import { coerceNumeric, KNOWN_VR_CODES } from './_xmlToJson';
 import type { DicomJsonModel, DicomJsonElement } from './_xmlToJson';
@@ -34,6 +34,8 @@ interface P10ParseOptions {
     readonly charsetAssume?: string | undefined;
     /** Charset to fall back to when the specified charset is unsupported. */
     readonly charsetFallback?: string | undefined;
+    /** Decode values detected as mislabeled UTF-8 as UTF-8 instead of the declared charset. A warning is pushed either way. */
+    readonly utf8MislabelPromote?: boolean | undefined;
 }
 
 /** Result of a successful buffer parse. */
@@ -167,17 +169,49 @@ function personNameToJson(value: string): Record<string, string> {
     return result;
 }
 
+/** Mutable UTF-8 mislabel state shared across one parse (warnings deduped per tag). */
+interface MislabelState {
+    /** Whether detected mislabels are decoded as UTF-8 instead of the declared charset. */
+    readonly promote: boolean;
+    /** Warning sink (one entry per distinct tag). */
+    readonly warnings: string[];
+    /** Tags already warned about. */
+    readonly seen: Set<string>;
+}
+
+/**
+ * Decodes charset-sensitive text bytes, detecting mislabeled UTF-8 under
+ * single-byte contexts (#34): bytes with a high byte that form valid UTF-8
+ * under a single-byte declared charset are near-certainly mislabeled.
+ */
+function decodeTextChecked(bytes: Uint8Array, tag: string, settings: ConvertSettings): string {
+    const { charset, mislabel } = settings;
+    if (charset.singleByte && isProbableUtf8Mislabel(bytes)) {
+        if (!mislabel.seen.has(tag)) {
+            mislabel.seen.add(tag);
+            const action = mislabel.promote ? 'decoded as UTF-8' : `decoded as '${charset.terms.join('\\')}'`;
+            mislabel.warnings.push(`possible UTF-8 mislabel: ${tag} (${action})`);
+        }
+        if (mislabel.promote) {
+            return decodeUtf8(bytes);
+        }
+    }
+    return decodeDicomText(bytes, charset);
+}
+
 /** Converts a PN element. */
-function convertPersonName(element: Element, byteArray: Uint8Array, charset: CharsetContext): DicomJsonElement {
-    const decoded = decodeDicomText(valueBytes(element, byteArray), charset);
+function convertPersonName(element: Element, byteArray: Uint8Array, settings: ConvertSettings): DicomJsonElement {
+    const decoded = decodeTextChecked(valueBytes(element, byteArray), toJsonTag(element.tag), settings);
     const values = decoded.split('\\').map(personNameToJson);
     return { vr: 'PN', Value: values };
 }
 
 /** Converts a text/string element (everything except SQ, PN, AT, binary, and fixed-width numerics). */
-function convertString(element: Element, byteArray: Uint8Array, vr: string, charset: CharsetContext): DicomJsonElement {
+function convertString(element: Element, byteArray: Uint8Array, vr: string, settings: ConvertSettings): DicomJsonElement {
     const bytes = valueBytes(element, byteArray);
-    const decoded = CHARSET_VRS.has(vr) ? decodeDicomText(bytes, charset) : Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('latin1');
+    const decoded = CHARSET_VRS.has(vr)
+        ? decodeTextChecked(bytes, toJsonTag(element.tag), settings)
+        : Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).toString('latin1');
     const rawValues = NO_SPLIT_VRS.has(vr) ? [decoded] : decoded.split('\\');
     const values: unknown[] = rawValues.map(v => {
         const trimmed = trimPadding(v);
@@ -193,6 +227,7 @@ function convertString(element: Element, byteArray: Uint8Array, vr: string, char
 interface ConvertSettings {
     readonly charset: CharsetContext;
     readonly littleEndian: boolean;
+    readonly mislabel: MislabelState;
 }
 
 /** Converts a non-sequence element to its DICOM JSON representation. */
@@ -215,9 +250,9 @@ function convertLeaf(element: Element, byteArray: Uint8Array, vr: string, settin
         return convertAttributeTag(element, byteArray, settings.littleEndian);
     }
     if (vr === 'PN') {
-        return convertPersonName(element, byteArray, settings.charset);
+        return convertPersonName(element, byteArray, settings);
     }
-    return convertString(element, byteArray, vr, settings.charset);
+    return convertString(element, byteArray, vr, settings);
 }
 
 /** A pending dataset conversion unit for the iterative sequence walk. */
@@ -261,9 +296,16 @@ function isSequence(element: Element, vr: string): boolean {
     return vr === 'SQ' || (element.vr === undefined && element.items !== undefined);
 }
 
+/** Per-parse state shared across all datasets of one file. */
+interface ParseState {
+    readonly littleEndian: boolean;
+    readonly options: P10ParseOptions | undefined;
+    readonly mislabel: MislabelState;
+}
+
 /** Converts all elements of one dataset into its output model. */
-function convertDataset(unit: WorkUnit, stack: WorkUnit[], littleEndian: boolean, options: P10ParseOptions | undefined): Result<void> {
-    const charsetResult = datasetCharset(unit.src, unit.parentCharset, options);
+function convertDataset(unit: WorkUnit, stack: WorkUnit[], state: ParseState): Result<void> {
+    const charsetResult = datasetCharset(unit.src, unit.parentCharset, state.options);
     if (!charsetResult.ok) {
         return err(charsetResult.error);
     }
@@ -279,7 +321,7 @@ function convertDataset(unit: WorkUnit, stack: WorkUnit[], littleEndian: boolean
         if (isSequence(element, vr)) {
             unit.out[tag] = convertSequence(element, stack, charset);
         } else {
-            unit.out[tag] = convertLeaf(element, unit.src.byteArray, vr, { charset, littleEndian });
+            unit.out[tag] = convertLeaf(element, unit.src.byteArray, vr, { charset, littleEndian: state.littleEndian, mislabel: state.mislabel });
         }
     }
     return ok(undefined);
@@ -322,6 +364,8 @@ function parseDicomBuffer(buffer: Uint8Array, options?: P10ParseOptions): Result
 
     const data: Record<string, DicomJsonElement> = {};
     const stack: WorkUnit[] = [{ src: dataSet, out: data, parentCharset: rootCharset.value }];
+    const mislabel: MislabelState = { promote: options?.utf8MislabelPromote === true, warnings: [], seen: new Set() };
+    const state: ParseState = { littleEndian, options, mislabel };
     let processed = 0;
     while (stack.length > 0) {
         processed++;
@@ -331,12 +375,12 @@ function parseDicomBuffer(buffer: Uint8Array, options?: P10ParseOptions): Result
         const unit = stack.pop();
         /* v8 ignore next -- stack.length > 0 guarantees an entry */
         if (unit === undefined) break;
-        const converted = convertDataset(unit, stack, littleEndian, options);
+        const converted = convertDataset(unit, stack, state);
         if (!converted.ok) {
             return err(converted.error);
         }
     }
-    return ok({ data, warnings: dataSet.warnings });
+    return ok({ data, warnings: [...dataSet.warnings, ...mislabel.warnings] });
 }
 
 export { parseDicomBuffer };

--- a/src/tools/dicom2json.test.ts
+++ b/src/tools/dicom2json.test.ts
@@ -122,6 +122,25 @@ describe('dicom2json', () => {
         expect(mockedDcm2json).not.toHaveBeenCalled();
     });
 
+    it('surfaces mislabel warnings and promotes with utf8MislabelPromote', async () => {
+        const mislabeledPath = join(tempDir, 'mislabeled.dcm');
+        await writeFile(mislabeledPath, p10(TS.explicitLE, [explicitEl('00100010', 'PN', evenPad(Buffer.from('Müller^José', 'utf-8').toString('latin1')))]));
+
+        const detected = await dicom2json(mislabeledPath);
+        expect(detected.ok).toBe(true);
+        if (detected.ok) {
+            expect(detected.value.data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'MÃ¼ller^JosÃ©' }] });
+            expect(detected.value.warnings).toContain("possible UTF-8 mislabel: 00100010 (decoded as 'ISO_IR 6')");
+        }
+
+        const promoted = await dicom2json(mislabeledPath, { utf8MislabelPromote: true });
+        expect(promoted.ok).toBe(true);
+        if (promoted.ok) {
+            expect(promoted.value.data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'Müller^José' }] });
+            expect(promoted.value.warnings).toContain('possible UTF-8 mislabel: 00100010 (decoded as UTF-8)');
+        }
+    });
+
     it('also falls back on file read errors when fallback is enabled', async () => {
         mockedDcm2json.mockResolvedValue(ok({ data: {}, source: 'xml' as const }));
         const result = await dicom2json(join(tempDir, 'nope.dcm'), { dcmtkFallback: true });
@@ -150,6 +169,16 @@ describe('dicom2jsonFromBuffer', () => {
     it('rejects unknown options', () => {
         const result = dicom2jsonFromBuffer(VALID_FILE, { timeoutMs: 5 } as never);
         expect(result.ok).toBe(false);
+    });
+
+    it('applies utf8MislabelPromote', () => {
+        const file = p10(TS.explicitLE, [explicitEl('00100010', 'PN', evenPad(Buffer.from('Müller', 'utf-8').toString('latin1')))]);
+        const result = dicom2jsonFromBuffer(file, { utf8MislabelPromote: true });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.data['00100010']).toEqual({ vr: 'PN', Value: [{ Alphabetic: 'Müller' }] });
+            expect(result.value.warnings).toHaveLength(1);
+        }
     });
 
     it('returns an error for a non-DICOM buffer', () => {

--- a/src/tools/dicom2json.ts
+++ b/src/tools/dicom2json.ts
@@ -37,12 +37,17 @@ interface Dicom2jsonOptions extends ToolBaseOptions {
     readonly charsetAssume?: string | undefined;
     /** Charset to decode with when the file's specified character set is unsupported. `'latin-1'` recommended — maps every byte to a valid character. */
     readonly charsetFallback?: string | undefined;
+    /**
+     * Decode values detected as mislabeled UTF-8 (high bytes forming valid UTF-8 under a single-byte declared charset)
+     * as UTF-8 instead of the declared charset. A `possible UTF-8 mislabel` warning is pushed either way. Defaults to false.
+     */
+    readonly utf8MislabelPromote?: boolean | undefined;
     /** Retry with the deprecated dcm2json binary path when the JS parser fails. Defaults to false. */
     readonly dcmtkFallback?: boolean | undefined;
 }
 
 /** Options for {@link dicom2jsonFromBuffer} (charset handling only). */
-type Dicom2jsonBufferOptions = Pick<Dicom2jsonOptions, 'charsetAssume' | 'charsetFallback'>;
+type Dicom2jsonBufferOptions = Pick<Dicom2jsonOptions, 'charsetAssume' | 'charsetFallback' | 'utf8MislabelPromote'>;
 
 /** Result of a successful dicom2json conversion. */
 interface Dicom2jsonResult {
@@ -60,6 +65,7 @@ const Dicom2jsonOptionsSchema = z
         signal: z.instanceof(AbortSignal).optional(),
         charsetAssume: z.string().min(1).optional(),
         charsetFallback: z.string().min(1).optional(),
+        utf8MislabelPromote: z.boolean().optional(),
         dcmtkFallback: z.boolean().optional(),
     })
     .strict()
@@ -69,6 +75,7 @@ const Dicom2jsonBufferOptionsSchema = z
     .object({
         charsetAssume: z.string().min(1).optional(),
         charsetFallback: z.string().min(1).optional(),
+        utf8MislabelPromote: z.boolean().optional(),
     })
     .strict()
     .optional();
@@ -148,7 +155,11 @@ async function parseFromFile(inputPath: string, timeoutMs: number, options?: Dic
     if (!fileResult.ok) {
         return err(fileResult.error);
     }
-    const parsed = parseDicomBuffer(fileResult.value, { charsetAssume: options?.charsetAssume, charsetFallback: options?.charsetFallback });
+    const parsed = parseDicomBuffer(fileResult.value, {
+        charsetAssume: options?.charsetAssume,
+        charsetFallback: options?.charsetFallback,
+        utf8MislabelPromote: options?.utf8MislabelPromote,
+    });
     if (!parsed.ok) {
         return err(parsed.error);
     }


### PR DESCRIPTION
## Summary

Fixes items 1 and 2 of #34 (item 3 spun off to #35).

### 1. UTF-8 mislabel detection (`src/tools/_charset.ts`, `_p10ToJson.ts`)

The JS engine's decoders can never fail on byte content, so files whose declared (or absent) SpecificCharacterSet contradicts their actual UTF-8 bytes — which `dcm2json` rejected with exit 80 — parsed "successfully" as mojibake with empty `warnings`.

- `CharsetContext` gains a `singleByte` flag (latin1/ASCII + the ISO 8859 family + windows-874; multi-byte and ISO 2022 contexts excluded — they can legitimately contain byte runs that also form valid UTF-8).
- When a charset-sensitive value (SH/LO/ST/LT/UC/UT/PN) under a single-byte context contains a byte ≥ 0x80 and the whole run is strict-valid UTF-8, a `possible UTF-8 mislabel: <tag>` warning is pushed (deduped per tag). In valid UTF-8 every high byte belongs to a multi-byte sequence, so the two checks together imply the ≥1-multi-byte-character condition.
- New opt-in `utf8MislabelPromote: true` decodes those values as UTF-8 instead. Warn-only stays the default — silently changing decode output would be its own behavioral surprise.

Before/after on the issue's repro (UTF-8 `Müller^José`, no 0008,0005):

```
rc.2 : [{"Alphabetic":"MÃ¼ller^JosÃ©"}] warnings=[]
now  : [{"Alphabetic":"MÃ¼ller^JosÃ©"}] warnings=["possible UTF-8 mislabel: 00100010 (decoded as 'ISO_IR 6')"]
promote: [{"Alphabetic":"Müller^José"}] warnings=["possible UTF-8 mislabel: 00100010 (decoded as UTF-8)"]
```

### 2. Warnings surface on `DicomInstance`

`readDicomJson` no longer discards the warnings channel: `DicomInstance.open` stores it, exposed as `instance.warnings` (preserved across fluent modifications; empty for `engine: 'dcmtk'` and `fromDataset()`). `DicomReceiver` `INSTANCE_RECEIVED` consumers read `data.instance.warnings`; `utf8MislabelPromote` and `engine` are accepted in `instanceOpenOptions` — the `engine` key was documented but rejected by the `.strict()` schema since rc.2 (fixed here).

Internal refactors for lint limits: `DicomInstance` constructor now takes a state object with a private `derive()` helper; `_p10ToJson` threads a `ParseState` bundle.

## Testing

- 2126 unit tests pass (17 new: `_charset`, `_p10ToJson`, `dicom2json`, `DicomInstance`)
- Coverage 94.79% stmts / 89.51% branch — above thresholds
- `dicom2json` integration suite (real DCMTK, 198-sample differential) passes
- Issue repro verified end-to-end (output above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uPsy9ynEd9gJVHrzprVH2