### PR TITLE
feat(tools): adopt @ubercode/dicom-parser 2.0 — swap engines, rewrite _boundedRead on parseHeadAsync (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- **Parser engine swapped to `@ubercode/dicom-parser@2.0.0-rc.2`**
+  ([#39](https://github.com/MichaelLeeHobbs/dcmtk.js/issues/39)) — the maintained TypeScript
+  fork of `dicom-parser`, consumed via its v1-compatible `/compat` facade. Verified: zero
+  ok/err flips and zero output diffs across the 201-file corpus (incl. `bad/`) vs rc.3, and
+  the full DCMTK differential passes. User-visible changes:
+    - Explicit-VR `SV`/`UV`/`OV` files now parse natively (former known limitation removed).
+    - Truncated-mid-value files parse with an `unexpected-eof` warning instead of failing;
+      inspect `warnings` where rejection semantics were relied on.
+- **`_boundedRead` rewritten on the fork's `parseHeadAsync`**: bulk-value discovery now runs
+  on the real tokenizer over ranged reads instead of chunk-probe heuristics; dcmtk.js only
+  assembles the synthetic buffer from the reported ranges, with a strict fragment-chain
+  validation (fork [#67](https://github.com/MichaelLeeHobbs/dicomParser/issues/67)) so
+  malformed encapsulated streams still fall back to whole-file behavior. The internal
+  `chunkBytes` tuning knob is gone (the fork manages its own read-ahead).
+
 ## [1.0.0-rc.3] - 2026-07-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ All code **shall** comply with `docs/TypeScript Coding Standard for Mission-Crit
 
 51 async functions wrapping DCMTK binaries, organized by category:
 
-- **Data & Metadata** — `dcm2xml`, `dicom2json` (pure-JS, no binary), `dcm2json` (deprecated), `dcmdump`, `dcmconv`, `dcmodify`, `dcmftest`, `dcmgpdir`, `dcmmkdir`, `dcmqridx`
+- **Data & Metadata** — `dcm2xml`, `dicom2json` (pure-JS via @ubercode/dicom-parser, no binary), `dcm2json` (deprecated), `dcmdump`, `dcmconv`, `dcmodify`, `dcmftest`, `dcmgpdir`, `dcmmkdir`, `dcmqridx`
 - **File Conversion** — `xml2dcm`, `json2dcm`, `dump2dcm`, `img2dcm`, `pdf2dcm`, `dcm2pdf`, `cda2dcm`, `dcm2cda`, `stl2dcm`
 - **Compression** — `dcmcrle`, `dcmdrle`, `dcmencap`, `dcmdecap`, `dcmcjpeg`, `dcmdjpeg`, `dcmcjpls`, `dcmdjpls`
 - **Image Processing** — `dcmj2pnm`, `dcm2pnm`, `dcmscale`, `dcmquant`, `dcmdspfn`, `dcod2lum`, `dconvlum`

--- a/docs/adr/006-pure-js-dicom-parsing.md
+++ b/docs/adr/006-pure-js-dicom-parsing.md
@@ -77,3 +77,23 @@ non-PixelData) grows the buffer or falls back to a full read, so behavior — in
 behavior on corrupt files — is byte-identical to the full path. Verified by a forced-bounded
 differential suite over all 198 samples (data + warnings equality; 98.4% fewer bytes read) plus
 alignment-sweep unit tests that walk element headers across chunk boundaries.
+
+## Addendum: engine swap to @ubercode/dicom-parser (2026-07-24, [#39](https://github.com/MichaelLeeHobbs/dcmtk.js/issues/39))
+
+`dicom-parser@1.8.21` is replaced by `@ubercode/dicom-parser@2.0.0-rc.2` — the maintained
+TypeScript fork ([MichaelLeeHobbs/dicomParser](https://github.com/MichaelLeeHobbs/dicomParser)).
+`_p10ToJson` consumes its `/compat` facade (the v1 surface), so the converter is unchanged;
+`_boundedRead` was rewritten on the fork's `parseHeadAsync` core API: bulk-range discovery now
+runs on the real tokenizer over ranged reads, and this module only assembles the synthetic
+zero-length-header buffer from the reported ranges (plus a strict fragment-chain validation,
+fork #67). The chunk-probe heuristics of the original implementation are gone.
+
+Behavior changes, all verified against the 201-file corpus (zero ok/err flips, zero output
+diffs) and the DCMTK differential:
+
+- Explicit-VR `SV`/`UV`/`OV` files now parse natively (the old known limitation).
+- Truncated-mid-value files parse with an `unexpected-eof` warning instead of failing (the
+  fork's salvage-and-warn posture; none of the corpus `bad/` files flip, since they fail at
+  the header level in both engines).
+- The fork core carries its own UTF-8 mislabel detection (ported from #34); `_p10ToJson`
+  filters those duplicates and keeps this library's documented warning format.

--- a/docs/tools/data-metadata.md
+++ b/docs/tools/data-metadata.md
@@ -83,8 +83,10 @@ Differences from the dcm2json binary path (both verified against `dcmdump` groun
 
 - File meta group 0002 elements are **included**, so `DicomDataset.transferSyntaxUID` works.
 - Private tags keep their real block numbers (dcm2xml renumbers private blocks incorrectly).
-- Known limitation: files using **explicit VR** `SV`/`UV`/`OV` (rare, 2019-era VRs) fail to
-  tokenize — enable `dcmtkFallback` to cover them. Implicit VR files are unaffected.
+- Explicit-VR `SV`/`UV`/`OV` files (rare, 2019-era VRs) parse natively — a former
+  `dicom-parser@1.8` limitation fixed by the `@ubercode/dicom-parser` engine.
+- Truncated files (a value cut off mid-stream) parse with an `unexpected-eof` warning
+  instead of failing — inspect `warnings` if rejection semantics are needed.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "LICENSE"
     ],
     "engines": {
-        "node": ">=20"
+        "node": ">=20.16"
     },
     "publishConfig": {
         "access": "public"

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
         ]
     },
     "dependencies": {
-        "dicom-parser": "1.8.21",
+        "@ubercode/dicom-parser": "2.0.0-rc.2",
         "fast-xml-parser": "5.8.0",
         "stderr-lib": "2.2.0",
         "tree-kill": "1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      dicom-parser:
-        specifier: 1.8.21
-        version: 1.8.21
+      '@ubercode/dicom-parser':
+        specifier: 2.0.0-rc.2
+        version: 2.0.0-rc.2
       fast-xml-parser:
         specifier: 5.8.0
         version: 5.8.0
@@ -548,6 +548,10 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@ubercode/dicom-parser@2.0.0-rc.2':
+    resolution: {integrity: sha512-ZAyzVI30SS3H50I+JtxYdNXKBCzRD5oMuxVccuu8CYAsWGOxMyfUmr8YRnRS3SSvevFaNiRRZsObr8M5O3AYvw==}
+    engines: {node: '>=20.16'}
+
   '@vitest/coverage-v8@4.0.18':
     resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
     peerDependencies:
@@ -692,9 +696,6 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
-  dicom-parser@1.8.21:
-    resolution: {integrity: sha512-lYCweHQDsC8UFpXErPlg86Px2A8bay0HiUY+wzoG3xv5GzgqVHU3lziwSc/Gzn7VV7y2KeP072SzCviuOoU02w==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1771,6 +1772,8 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
+  '@ubercode/dicom-parser@2.0.0-rc.2': {}
+
   '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.3.3)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -1908,8 +1911,6 @@ snapshots:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
-
-  dicom-parser@1.8.21: {}
 
   emoji-regex@10.6.0: {}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -83,9 +83,6 @@ const MAX_OUTPUT_BYTES = 100 * 1024 * 1024;
 /** Files at or below this size are read whole by the bounded reader (8 MB). */
 const BOUNDED_READ_THRESHOLD_BYTES = 8 * 1024 * 1024;
 
-/** Initial and incremental chunk size for the bounded reader (1 MB). */
-const BOUNDED_READ_CHUNK_BYTES = 1024 * 1024;
-
 export {
     DEFAULT_TIMEOUT_MS,
     DEFAULT_START_TIMEOUT_MS,
@@ -102,5 +99,4 @@ export {
     MAX_CHANGESET_OPERATIONS,
     MAX_OUTPUT_BYTES,
     BOUNDED_READ_THRESHOLD_BYTES,
-    BOUNDED_READ_CHUNK_BYTES,
 };

--- a/src/tools/_boundedRead.test.ts
+++ b/src/tools/_boundedRead.test.ts
@@ -7,7 +7,7 @@ import { readDicomHead } from './_boundedRead';
 import { parseDicomBuffer } from './_p10ToJson';
 import { TS, evenPad, explicitEl, implicitEl, sqExplicit, encapsulatedPixelData, item, metaGroup, p10, tagBytes } from '../../test/helpers/p10';
 
-/** Forces the bounded path regardless of file size, with small chunks. */
+/** Forces the bounded path regardless of file size (thresholdBytes 0). */
 const FORCE = { timeoutMs: 5_000, thresholdBytes: 0 } as const;
 
 let tempDir: string;
@@ -290,6 +290,16 @@ describe('readDicomHead — malformed structures fall back to full reads', () =>
         const head12 = Buffer.concat([explicitEl('7FE00010', 'OB', Buffer.alloc(0)).subarray(0, 8), Buffer.from([0xff, 0xff, 0xff, 0xff])]);
         return Buffer.concat([head12, itemStream]);
     }
+
+    it('falls back for defined-length encapsulated pixel data (item-shaped value in a compressed TS)', async () => {
+        // The full parse scans the item structure of a defined-length pixel
+        // value in a compressed transfer syntax (upstream #59/#60); elision
+        // would hide it, so these files must read whole.
+        const itemStream = Buffer.concat([item(Buffer.alloc(0)), item(Buffer.alloc(9_000, 0xfe))]);
+        const file = p10(TS.jpegBaseline, [explicitEl('00100020', 'LO', evenPad('PAT001')), explicitEl('7FE00010', 'OB', itemStream)]);
+        const assembled = await expectEquivalent(file);
+        expect(assembled.length).toBe(file.length); // whole-file fallback, not elision
+    });
 
     it('falls back when a fragment item overruns the file', async () => {
         const fragmentHeader = Buffer.concat([

--- a/src/tools/_boundedRead.test.ts
+++ b/src/tools/_boundedRead.test.ts
@@ -8,7 +8,7 @@ import { parseDicomBuffer } from './_p10ToJson';
 import { TS, evenPad, explicitEl, implicitEl, sqExplicit, encapsulatedPixelData, item, metaGroup, p10, tagBytes } from '../../test/helpers/p10';
 
 /** Forces the bounded path regardless of file size, with small chunks. */
-const FORCE = { timeoutMs: 5_000, thresholdBytes: 0, chunkBytes: 256 } as const;
+const FORCE = { timeoutMs: 5_000, thresholdBytes: 0 } as const;
 
 let tempDir: string;
 let fileCounter = 0;

--- a/src/tools/_boundedRead.ts
+++ b/src/tools/_boundedRead.ts
@@ -37,6 +37,7 @@ import { lookupTag } from '../dicom/dictionary';
 
 const TAG_PIXEL_DATA = 0x7fe00010;
 const TS_IMPLICIT_LE = '1.2.840.10008.1.2';
+const TS_DEFLATED_LE = '1.2.840.10008.1.2.1.99';
 
 /** Transfer syntaxes whose pixel data is native (not encapsulated in fragments). */
 const NATIVE_TRANSFER_SYNTAXES: ReadonlySet<string> = new Set(['1.2.840.10008.1.2', '1.2.840.10008.1.2.1', '1.2.840.10008.1.2.2', '1.2.840.10008.1.2.1.99']);
@@ -113,16 +114,23 @@ function coreVrLookup(tag: number): string | undefined {
     return lookupTag(tag.toString(16).padStart(8, '0'))?.vr;
 }
 
-/** Runs the fork's head walk over a file handle. */
-async function discoverHead(handle: FileHandle, fileSize: number): Promise<HeadResult> {
+/** Runs the fork's head walk over a file handle, honoring abort/deadline between reads. */
+async function discoverHead(handle: FileHandle, fileSize: number, guard: Guard): Promise<HeadResult> {
     const reader: RangeReader = {
         size: fileSize,
         read: async (offset: number, length: number): Promise<Uint8Array> => {
+            const abort = checkAbort(guard);
+            /* v8 ignore next 3 -- deterministic tests cannot abort mid-discovery (pre-flight aborts exit earlier) */
+            if (abort !== undefined) {
+                throw abort;
+            }
             const want = Math.min(length, fileSize - offset);
+            /* v8 ignore next 3 -- defensive: the fork's reader never requests past its declared size */
             if (want <= 0) {
                 return new Uint8Array(0);
             }
             const result = await readRange(handle, offset, want);
+            /* v8 ignore next 3 -- read failures require concurrent file mutation */
             if (!result.ok) {
                 throw result.error;
             }
@@ -139,6 +147,13 @@ async function discoverHead(handle: FileHandle, fileSize: number): Promise<HeadR
  */
 function headUsable(head: HeadResult): boolean {
     if (!head.ok || head.error !== undefined || head.bulk.size === 0) {
+        return false;
+    }
+    // Deflated files can't be elided (offsets refer to compressed bytes). The
+    // fork already reads them whole (bulk stays empty, caught above); this
+    // guard makes the exclusion explicit rather than transitive.
+    /* v8 ignore next 3 -- unreachable defense-in-depth: deflated always has an empty bulk map */
+    if (head.transferSyntax === TS_DEFLATED_LE) {
         return false;
     }
     return !head.warnings.some(w => w.code === 'unexpected-eof');
@@ -163,19 +178,38 @@ interface Patch {
  * the 4 bytes before the value. Encapsulated pixel data additionally gets its
  * VR normalized to OB, matching the full parse's fragment handling.
  */
+/** Validates that the sorted ranges are in-bounds and non-overlapping (defensive vs upstream bugs). */
+function rangesWellFormed(ranges: readonly { readonly offset: number; readonly length: number }[], fileSize: number): boolean {
+    let previousEnd = 0;
+    for (const range of ranges) {
+        /* v8 ignore next 3 -- defensive: the fork reports ordered in-bounds ranges */
+        if (range.offset < previousEnd || range.length < 0 || range.offset + range.length > fileSize) {
+            return false;
+        }
+        previousEnd = range.offset + range.length;
+    }
+    return true;
+}
+
 async function assemble(handle: FileHandle, fileSize: number, head: HeadResult, guard: Guard): Promise<Result<Buffer>> {
     const explicitVr = head.transferSyntax !== TS_IMPLICIT_LE;
     const ranges = [...head.bulk.values()].sort((a, b) => a.offset - b.offset);
+    /* v8 ignore next 3 -- defensive: reachable only via a fork range-reporting bug */
+    if (!rangesWellFormed(ranges, fileSize)) {
+        return err(new Error('bulk ranges overlap or exceed the file'));
+    }
     const parts: Buffer[] = [];
     const patches: Patch[] = [];
     let filePos = 0;
     let skipped = 0;
     for (const range of ranges) {
         const abort = checkAbort(guard);
+        /* v8 ignore next 3 -- deterministic tests cannot abort mid-assembly (pre-flight aborts exit earlier) */
         if (abort !== undefined) {
             return err(abort);
         }
         const keep = await readRange(handle, filePos, range.offset - filePos);
+        /* v8 ignore next 3 -- read failures require concurrent file mutation */
         if (!keep.ok) {
             return err(keep.error);
         }
@@ -185,6 +219,7 @@ async function assemble(handle: FileHandle, fileSize: number, head: HeadResult, 
         skipped += range.length;
     }
     const tail = await readRange(handle, filePos, fileSize - filePos);
+    /* v8 ignore next 3 -- read failures require concurrent file mutation */
     if (!tail.ok) {
         return err(tail.error);
     }
@@ -281,11 +316,13 @@ async function readWhole(handle: FileHandle, fileSize: number, guard: Guard): Pr
 }
 
 /** Discovery + safety checks: the head result, or undefined when elision must not be used. */
-async function usableHead(handle: FileHandle, fileSize: number): Promise<HeadResult | undefined> {
+async function usableHead(handle: FileHandle, fileSize: number, guard: Guard): Promise<HeadResult | undefined> {
     let head: HeadResult;
     try {
-        head = await discoverHead(handle, fileSize);
+        head = await discoverHead(handle, fileSize, guard);
     } catch {
+        // abort/timeout surfaces via the caller's next checkAbort; other
+        // failures (unreadable structure) fall back to a whole read
         return undefined;
     }
     if (!headUsable(head) || (await hasDefinedLengthEncapsulation(handle, head)) || !(await encapsulatedRangesValid(handle, head))) {
@@ -306,16 +343,16 @@ async function readWithHandle(handle: FileHandle, options: BoundedReadOptions): 
     if (fileSize <= threshold) {
         return readWhole(handle, fileSize, guard);
     }
-    const head = await usableHead(handle, fileSize);
+    const head = await usableHead(handle, fileSize, guard);
     if (head === undefined) {
         return readWhole(handle, fileSize, guard);
     }
     const assembled = await assemble(handle, fileSize, head, guard);
+    /* v8 ignore next 7 -- assemble fails only on mid-flight abort (race) or concurrent file mutation */
     if (!assembled.ok) {
         if (assembled.error.message.startsWith('aborted') || assembled.error.message.startsWith('timed out')) {
             return err(assembled.error);
         }
-        /* v8 ignore next 2 -- IO failures mid-assembly require concurrent file mutation */
         return readWhole(handle, fileSize, guard);
     }
     return assembled;

--- a/src/tools/_boundedRead.ts
+++ b/src/tools/_boundedRead.ts
@@ -1,26 +1,22 @@
 /**
- * Bounded head-read for the pure-JS DICOM parser (#35).
+ * Bounded head-read for the pure-JS DICOM parser (#35, #39).
  *
- * `dicom2json` only ever emits bare `{ vr }` for bulk binary VRs, and DICOM
- * elements are stored in ascending tag order — so for large files the bulk of
- * the bytes (PixelData and friends) are read and then discarded. This module
- * reads only what the JSON Model actually needs: it reads the file in chunks,
- * probes each chunk with `dicom-parser`, and when the parse stops inside a
- * bulk-VR value it rewrites that element's length to zero in the assembled
- * buffer and resumes reading after the value. The result is a well-formed
- * synthetic Part-10 buffer whose parse output is identical to the full file's
- * — with peak memory proportional to the metadata, not the file.
+ * `dicom2json` only ever emits bare `{ vr }` for bulk binary VRs, so for large
+ * files the bulk of the bytes (PixelData and friends) are read and then
+ * discarded. This module reads only what the JSON Model needs: bulk-value
+ * discovery is delegated to `@ubercode/dicom-parser`'s `parseHeadAsync` (which
+ * walks the file with the real tokenizer over ranged reads), and the reported
+ * ranges are elided from a synthetic Part-10 buffer — each skipped element
+ * keeps its header with the length field rewritten to zero, so the buffer
+ * parses identically to the full file through the same converter.
  *
  * Correctness rules:
- * - A skip happens ONLY when the stall point is provably a bulk-VR element
- *   (defined length, or undefined-length OB/OW encapsulated pixel data whose
- *   fragments are hopped via 8-byte header reads). Every ambiguous case grows
- *   the buffer instead, degrading to a full read.
- * - A successful probe is accepted ONLY once the entire file has been
- *   consumed (read or skipped) — a parse that happens to succeed on a
- *   truncated buffer is never trusted.
- * - Deflated transfer syntax, files at or below the size threshold, and any
- *   structural surprise fall back to reading the whole file.
+ * - Only ranges the fork proves bulk are elided; anything it copied
+ *   (sequences, text, ambiguous VRs) is read verbatim.
+ * - Truncated files (`unexpected-eof`), parse failures, deflated transfer
+ *   syntax, and defined-length encapsulated pixel data (rare; the elided value
+ *   would hide the item structure the full parse keys on) fall back to reading
+ *   the whole file, so behavior — including warnings — matches a full read.
  *
  * @module _boundedRead
  * @internal
@@ -28,40 +24,30 @@
 
 import { open } from 'node:fs/promises';
 import type { FileHandle } from 'node:fs/promises';
-import dicomParser from 'dicom-parser';
-import type { DataSet, Element } from 'dicom-parser';
+import { parseHeadAsync } from '@ubercode/dicom-parser';
+import type { HeadResult, RangeReader } from '@ubercode/dicom-parser';
 import type { Result } from '../types';
 import { ok, err } from '../types';
-import { BOUNDED_READ_CHUNK_BYTES, BOUNDED_READ_THRESHOLD_BYTES } from '../constants';
-import { implicitVrLookup } from './_p10ToJson';
+import { BOUNDED_READ_THRESHOLD_BYTES } from '../constants';
+import { lookupTag } from '../dicom/dictionary';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
+const TAG_PIXEL_DATA = 0x7fe00010;
 const TS_IMPLICIT_LE = '1.2.840.10008.1.2';
-const TS_EXPLICIT_BE = '1.2.840.10008.1.2.2';
-const TS_DEFLATED_LE = '1.2.840.10008.1.2.1.99';
 
-/** VRs whose values the converter never loads (bare `{ vr }` output). */
-const BULK_VRS = new Set(['OB', 'OW', 'OD', 'OF', 'OL', 'OV', 'UN']);
-
-/** VRs encoded with the 12-byte (long) explicit header form. */
-const LONG_FORM_VRS = new Set(['OB', 'OW', 'OF', 'OD', 'OL', 'OV', 'SQ', 'UC', 'UR', 'UT', 'UN', 'SV', 'UV']);
-
-const UNDEFINED_LENGTH = 0xffffffff;
-
-/** Longest element header (explicit long form). */
-const MAX_HEADER_BYTES = 12;
-
-/** Bound on skip/grow iterations per file (Rule 8.1). */
-const MAX_ITERATIONS = 10_000;
-
-/** Bound on encapsulated fragment hops per element (Rule 8.1). */
-const MAX_FRAGMENT_HOPS = 100_000;
+/** Transfer syntaxes whose pixel data is native (not encapsulated in fragments). */
+const NATIVE_TRANSFER_SYNTAXES: ReadonlySet<string> = new Set(['1.2.840.10008.1.2', '1.2.840.10008.1.2.1', '1.2.840.10008.1.2.2', '1.2.840.10008.1.2.1.99']);
 
 /** Bound on single-read retries when the OS returns short reads (Rule 8.1). */
 const MAX_READ_CALLS = 10_000;
+
+/** Bound on fragment items validated per encapsulated element (Rule 8.1). */
+const MAX_FRAGMENT_HOPS = 100_000;
+
+const UNDEFINED_LENGTH = 0xffffffff;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -75,47 +61,14 @@ interface BoundedReadOptions {
     readonly signal?: AbortSignal | undefined;
     /** Files at or below this size are read whole. Defaults to {@link BOUNDED_READ_THRESHOLD_BYTES}. */
     readonly thresholdBytes?: number | undefined;
-    /** Initial/incremental chunk size. Defaults to {@link BOUNDED_READ_CHUNK_BYTES}. */
-    readonly chunkBytes?: number | undefined;
 }
 
-/** Mutable state of one bounded read. */
-interface ReadState {
-    readonly handle: FileHandle;
-    readonly fileSize: number;
-    readonly chunkBytes: number;
-    readonly explicitVr: boolean;
-    readonly bigEndian: boolean;
-    readonly metaEnd: number;
+/** Abort/deadline context threaded through the reads. */
+interface Guard {
     readonly deadline: number;
     readonly timeoutMs: number;
     readonly signal: AbortSignal | undefined;
-    /** The synthetic buffer: file bytes read so far, minus skipped bulk values (their headers rewritten to length 0). */
-    assembled: Buffer;
-    /** Next unread file offset. Invariant: filePos - assembled.length = total bytes skipped. */
-    filePos: number;
-    /** Bytes to append on the next grow (doubles on consecutive grows). */
-    growSize: number;
 }
-
-/** A parsed element header at a stall point. */
-interface ElementHeader {
-    /** Tag as 8 lowercase hex chars ('7fe00010'). */
-    readonly tag: string;
-    readonly vr: string;
-    readonly length: number;
-    readonly headerLen: number;
-    /** Offset of the length field within the header (for rewriting). */
-    readonly lengthOffset: number;
-}
-
-/** What to do after a probe. */
-type ProbeAction =
-    | { readonly kind: 'done' }
-    | { readonly kind: 'fullRead' }
-    | { readonly kind: 'grow' }
-    | { readonly kind: 'skipDefined'; readonly headerEnd: number; readonly valueLength: number }
-    | { readonly kind: 'skipEncapsulated'; readonly headerStart: number; readonly headerEnd: number };
 
 // ---------------------------------------------------------------------------
 // Low-level IO
@@ -141,434 +94,231 @@ async function readRange(handle: FileHandle, position: number, length: number): 
 }
 
 /** Returns an error when the deadline passed or the signal aborted, undefined otherwise. */
-function checkAbort(state: Pick<ReadState, 'deadline' | 'signal' | 'timeoutMs'>): Error | undefined {
-    if (state.signal?.aborted === true) {
+function checkAbort(guard: Guard): Error | undefined {
+    if (guard.signal?.aborted === true) {
         return new Error('aborted');
     }
-    if (Date.now() > state.deadline) {
-        return new Error(`timed out after ${String(state.timeoutMs)}ms`);
+    if (Date.now() > guard.deadline) {
+        return new Error(`timed out after ${String(guard.timeoutMs)}ms`);
     }
     return undefined;
 }
 
 // ---------------------------------------------------------------------------
-// Meta probe
+// Head discovery (delegated to the fork's parseHeadAsync)
 // ---------------------------------------------------------------------------
 
-/** Minimal typing for dicom-parser's untyped readPart10Header export. */
-interface MetaHeader {
-    readonly position?: number;
-    readonly elements: Record<string, Element | undefined>;
+/** VR resolver for implicit transfer syntaxes, backed by the tag dictionary (core Tag form). */
+function coreVrLookup(tag: number): string | undefined {
+    return lookupTag(tag.toString(16).padStart(8, '0'))?.vr;
 }
 
-const readPart10Header = (dicomParser as unknown as { readPart10Header: (byteArray: Uint8Array) => MetaHeader }).readPart10Header;
-
-/** Parsed file meta info needed to drive the bounded read. */
-interface MetaInfo {
-    readonly metaEnd: number;
-    readonly transferSyntax: string;
+/** Runs the fork's head walk over a file handle. */
+async function discoverHead(handle: FileHandle, fileSize: number): Promise<HeadResult> {
+    const reader: RangeReader = {
+        size: fileSize,
+        read: async (offset: number, length: number): Promise<Uint8Array> => {
+            const want = Math.min(length, fileSize - offset);
+            if (want <= 0) {
+                return new Uint8Array(0);
+            }
+            const result = await readRange(handle, offset, want);
+            if (!result.ok) {
+                throw result.error;
+            }
+            return result.value;
+        },
+    };
+    return parseHeadAsync(reader, { vrLookup: coreVrLookup });
 }
 
-/** Reads the file meta group from the head chunk. Returns undefined on any surprise (caller falls back to a full read). */
-function probeMeta(head: Buffer): MetaInfo | undefined {
-    let meta: MetaHeader;
-    try {
-        meta = readPart10Header(head);
-    } catch {
-        return undefined;
+/**
+ * Whether the head result supports safe elision, or the whole file must be
+ * read. Truncated files must fall back so the full path owns the (identical)
+ * clamp-and-warn behavior; a head that skipped nothing has no elision to do.
+ */
+function headUsable(head: HeadResult): boolean {
+    if (!head.ok || head.error !== undefined || head.bulk.size === 0) {
+        return false;
     }
-    const tsElement = meta.elements['x00020010'];
-    if (meta.position === undefined || tsElement === undefined) {
-        return undefined;
-    }
-    const transferSyntax = head
-        .subarray(tsElement.dataOffset, tsElement.dataOffset + tsElement.length)
-        .toString('latin1')
-        .replace(/[\0 ]+$/u, '');
-    return { metaEnd: meta.position, transferSyntax };
+    return !head.warnings.some(w => w.code === 'unexpected-eof');
 }
 
 // ---------------------------------------------------------------------------
-// Probe + decision
+// Synthetic-buffer assembly
 // ---------------------------------------------------------------------------
 
-/** Outcome of parsing the assembled buffer with dicom-parser. */
-interface ProbeResult {
-    readonly dataSet: DataSet | undefined;
-    readonly threw: boolean;
+/** A header patch to apply after concatenation (offsets in the assembled buffer). */
+interface Patch {
+    /** Position of the 4-byte length field of a skipped element. */
+    readonly lengthFieldPos: number;
+    /** Rewrite the VR bytes (at lengthFieldPos - 4) to OB — encapsulated normalization. */
+    readonly forceObVr: boolean;
 }
 
-/** True when the thrown value carries a partially parsed dataset. */
-function hasPartialDataSet(e: unknown): e is { readonly dataSet: DataSet } {
-    return typeof e === 'object' && e !== null && 'dataSet' in e;
-}
-
-/** Parses the assembled buffer, capturing the partial dataset on failure. */
-function probeParse(assembled: Buffer): ProbeResult {
-    try {
-        return { dataSet: dicomParser.parseDicom(assembled, { vrCallback: implicitVrLookup }), threw: false };
-    } catch (e: unknown) {
-        return { dataSet: hasPartialDataSet(e) ? e.dataSet : undefined, threw: true };
+/**
+ * Assembles the synthetic buffer: all file bytes except the bulk value ranges,
+ * with each skipped element's length field zeroed. Bulk VRs always use a
+ * 4-byte length field (long-form explicit or implicit), so the field sits in
+ * the 4 bytes before the value. Encapsulated pixel data additionally gets its
+ * VR normalized to OB, matching the full parse's fragment handling.
+ */
+async function assemble(handle: FileHandle, fileSize: number, head: HeadResult, guard: Guard): Promise<Result<Buffer>> {
+    const explicitVr = head.transferSyntax !== TS_IMPLICIT_LE;
+    const ranges = [...head.bulk.values()].sort((a, b) => a.offset - b.offset);
+    const parts: Buffer[] = [];
+    const patches: Patch[] = [];
+    let filePos = 0;
+    let skipped = 0;
+    for (const range of ranges) {
+        const abort = checkAbort(guard);
+        if (abort !== undefined) {
+            return err(abort);
+        }
+        const keep = await readRange(handle, filePos, range.offset - filePos);
+        if (!keep.ok) {
+            return err(keep.error);
+        }
+        parts.push(keep.value);
+        patches.push({ lengthFieldPos: range.offset - skipped - 4, forceObVr: explicitVr && range.encapsulated === true });
+        filePos = range.offset + range.length;
+        skipped += range.length;
     }
-}
-
-/** The element with the largest extent (dataOffset + length), or undefined when empty. */
-function maxExtentElement(dataSet: DataSet): Element | undefined {
-    let best: Element | undefined;
-    let bestEnd = -1;
-    for (const key of Object.keys(dataSet.elements)) {
-        const element = dataSet.elements[key];
-        /* v8 ignore next -- keys come from the object itself */
-        if (element === undefined) continue;
-        const end = element.dataOffset + element.length;
-        if (end > bestEnd) {
-            bestEnd = end;
-            best = element;
+    const tail = await readRange(handle, filePos, fileSize - filePos);
+    if (!tail.ok) {
+        return err(tail.error);
+    }
+    parts.push(tail.value);
+    const assembled = Buffer.concat(parts);
+    for (const patch of patches) {
+        assembled.writeUInt32LE(0, patch.lengthFieldPos); // four zero bytes — endian-neutral
+        if (patch.forceObVr) {
+            assembled.write('OB', patch.lengthFieldPos - 4, 'latin1');
         }
     }
-    return best;
-}
-
-/** Formats a tag from group/element numbers as 8 lowercase hex chars. */
-function formatTag(group: number, elementNum: number): string {
-    return group.toString(16).padStart(4, '0') + elementNum.toString(16).padStart(4, '0');
-}
-
-/** Reads the element header at `position` in the assembled buffer, or undefined when unparseable. */
-function parseElementHeader(assembled: Buffer, position: number, state: Pick<ReadState, 'explicitVr' | 'bigEndian'>): ElementHeader | undefined {
-    if (position + MAX_HEADER_BYTES > assembled.length) {
-        return undefined;
-    }
-    if (!state.explicitVr) {
-        const tag = formatTag(assembled.readUInt16LE(position), assembled.readUInt16LE(position + 2));
-        const vr = implicitVrLookup(`x${tag}`) ?? 'UN';
-        return { tag, vr, length: assembled.readUInt32LE(position + 4), headerLen: 8, lengthOffset: 4 };
-    }
-    const tag = state.bigEndian
-        ? formatTag(assembled.readUInt16BE(position), assembled.readUInt16BE(position + 2))
-        : formatTag(assembled.readUInt16LE(position), assembled.readUInt16LE(position + 2));
-    const vr = assembled.subarray(position + 4, position + 6).toString('latin1');
-    if (!/^[A-Z]{2}$/u.test(vr)) {
-        return undefined;
-    }
-    if (LONG_FORM_VRS.has(vr)) {
-        const length = state.bigEndian ? assembled.readUInt32BE(position + 8) : assembled.readUInt32LE(position + 8);
-        return { tag, vr, length, headerLen: 12, lengthOffset: 8 };
-    }
-    const length = state.bigEndian ? assembled.readUInt16BE(position + 6) : assembled.readUInt16LE(position + 6);
-    return { tag, vr, length, headerLen: 8, lengthOffset: 6 };
+    return ok(assembled);
 }
 
 /**
- * Decision for a probe that threw.
- *
- * Two stall shapes:
- * - the incomplete element was recorded before the "buffer overrun" throw
- *   (defined-length value extending past the buffer) — its extent exceeds the
- *   buffer, so it is resolved like the success case via {@link decideOversized};
- * - the throw happened mid-header, inside sequence items, or inside
- *   encapsulated fragments (element not recorded) — the stall element's header
- *   sits at the end of the last recorded element, so it is parsed from there.
+ * Detects the rare defined-length encapsulated pixel data (compressed transfer
+ * syntax, defined length, value starting with an item tag): the full parse
+ * scans its item structure, which elision would hide — those files fall back.
  */
-function decideAfterThrow(probe: ProbeResult, state: ReadState): ProbeAction {
-    if (state.filePos >= state.fileSize) {
-        return { kind: 'fullRead' };
+async function hasDefinedLengthEncapsulation(handle: FileHandle, head: HeadResult): Promise<boolean> {
+    if (NATIVE_TRANSFER_SYNTAXES.has(head.transferSyntax)) {
+        return false;
     }
-    /* v8 ignore next 3 -- parse failures before the data set starts cannot occur once probeMeta succeeded */
-    if (probe.dataSet === undefined) {
-        return { kind: 'grow' };
-    }
-    const last = maxExtentElement(probe.dataSet);
-    const maxEnd = last === undefined ? state.metaEnd : last.dataOffset + last.length;
-    if (last !== undefined && maxEnd > state.assembled.length) {
-        return decideOversized(last, last.hadUndefinedLength === true, state);
-    }
-    const header = parseElementHeader(state.assembled, maxEnd, state);
-    if (header === undefined) {
-        return { kind: 'grow' };
-    }
-    return decideWithHeader(state, maxEnd, header, header.length === UNDEFINED_LENGTH);
-}
-
-/**
- * Final skip/grow decision once a stall element's header is known.
- *
- * Undefined-length hopping is restricted to explicit little-endian PixelData
- * (7FE0,0010) — the only element the full parse treats as encapsulated
- * fragments and normalizes to OB. Any other undefined-length element grows,
- * so its parse (and output VR) stays byte-identical to the full path.
- */
-function decideWithHeader(state: ReadState, position: number, header: ElementHeader, undefinedLength: boolean): ProbeAction {
-    if (undefinedLength) {
-        if (header.tag === '7fe00010' && (header.vr === 'OB' || header.vr === 'OW') && state.explicitVr && !state.bigEndian) {
-            rewriteHeader(state.assembled, position, header, true);
-            return { kind: 'skipEncapsulated', headerStart: position, headerEnd: position + header.headerLen };
+    for (const [tag, range] of head.bulk) {
+        if (tag !== TAG_PIXEL_DATA || range.encapsulated === true || range.length < 4) {
+            continue;
         }
-        return { kind: 'grow' };
-    }
-    if (BULK_VRS.has(header.vr)) {
-        return rewriteAndSkip(state, position, header);
-    }
-    return { kind: 'grow' };
-}
-
-/**
- * Rewrites the length field of the header at `position` to zero (zero is
- * endianness-neutral). `forceObVr` additionally rewrites the VR bytes to OB —
- * used for encapsulated skips so the output matches the full parse, which
- * normalizes encapsulated pixel data to OB (PS3.5 A.4).
- */
-function rewriteHeader(assembled: Buffer, position: number, header: ElementHeader, forceObVr: boolean): void {
-    /* v8 ignore next 3 -- short-form VRs are never bulk, so skips only rewrite 4-byte lengths */
-    if (header.lengthOffset === 6) {
-        assembled.writeUInt16LE(0, position + header.lengthOffset);
-    } else {
-        assembled.writeUInt32LE(0, position + header.lengthOffset);
-    }
-    if (forceObVr) {
-        assembled.write('OB', position + 4, 'latin1');
-    }
-}
-
-/** Zeroes the header length and returns the defined-length skip action. */
-function rewriteAndSkip(state: ReadState, position: number, header: ElementHeader): ProbeAction {
-    rewriteHeader(state.assembled, position, header, false);
-    return { kind: 'skipDefined', headerEnd: position + header.headerLen, valueLength: header.length };
-}
-
-/**
- * Decision for a probe that parsed cleanly.
- *
- * A clean parse of a partial buffer happens in two shapes:
- * - an oversized defined-length value: dicom-parser seeks past the end
- *   without error, leaving the last element's extent beyond the buffer;
- * - a silently truncated undefined-length value: its length is clamped to
- *   the buffer end. This is indistinguishable from a delimiter landing
- *   exactly on the chunk boundary — both resolve identically, because the
- *   fragment hop re-walks the item chain in the file and lands on the true
- *   end either way.
- */
-function decideAfterSuccess(probe: ProbeResult, state: ReadState): ProbeAction {
-    /* v8 ignore next -- a clean parse always has a dataset */
-    if (probe.dataSet === undefined) return { kind: 'fullRead' };
-    const last = maxExtentElement(probe.dataSet);
-    const maxEnd = last === undefined ? state.metaEnd : last.dataOffset + last.length;
-    const undefinedAtEnd = last?.hadUndefinedLength === true && maxEnd >= state.assembled.length;
-    if (state.filePos >= state.fileSize) {
-        // Whole file consumed. If maxEnd still exceeds the buffer the file
-        // itself ends mid-value; the assembled buffer then matches what a
-        // full read would contain, so the normal path handles it identically.
-        return { kind: 'done' };
-    }
-    if (maxEnd <= state.assembled.length && !undefinedAtEnd) {
-        return { kind: 'grow' };
-    }
-    /* v8 ignore next -- maxEnd > length implies an element exists */
-    if (last === undefined) return { kind: 'grow' };
-    return decideOversized(last, undefinedAtEnd, state);
-}
-
-/** Decision for a completed-probe element that extends to or beyond the buffer end. */
-function decideOversized(last: Element, undefinedAtEnd: boolean, state: ReadState): ProbeAction {
-    const headerStart = findHeaderStart(state.assembled, last, state);
-    if (headerStart === undefined) {
-        return { kind: 'grow' };
-    }
-    const header = parseElementHeader(state.assembled, headerStart, state);
-    /* v8 ignore next -- the same header already parsed via dicom-parser */
-    if (header === undefined) return { kind: 'grow' };
-    /* v8 ignore next 3 -- defensive cross-check: both lengths come from the same header bytes */
-    if (!undefinedAtEnd && header.length !== last.length) {
-        return { kind: 'grow' };
-    }
-    return decideWithHeader(state, headerStart, header, undefinedAtEnd);
-}
-
-/** Locates the header start of an element from its value offset, validating the round trip. */
-function findHeaderStart(assembled: Buffer, element: Element, state: Pick<ReadState, 'explicitVr' | 'bigEndian'>): number | undefined {
-    const candidates = state.explicitVr ? [12, 8] : [8];
-    for (const headerLen of candidates) {
-        const start = element.dataOffset - headerLen;
-        if (start < 0) continue;
-        const header = parseElementHeader(assembled, start, state);
-        if (header !== undefined && header.headerLen === headerLen) {
-            return start;
+        const probe = await readRange(handle, range.offset, 4);
+        if (probe.ok && probe.value.readUInt16LE(0) === 0xfffe && probe.value.readUInt16LE(2) === 0xe000) {
+            return true;
         }
     }
-    return undefined;
-}
-
-// ---------------------------------------------------------------------------
-// Skip application
-// ---------------------------------------------------------------------------
-
-/** File offset corresponding to a position in the assembled buffer's tail region. */
-function fileOffsetOf(state: ReadState, assembledPos: number): number {
-    return state.filePos - (state.assembled.length - assembledPos);
+    return false;
 }
 
 /**
- * Truncates the assembled buffer after a skipped element's header and
- * repositions the file cursor. Errs when the declared value extends beyond
- * EOF — the file is truncated, and the full-read path must handle it so the
- * error behavior matches a full parse exactly.
+ * Strictly validates an encapsulated range's fragment chain: every item must be
+ * a defined-length (FFFE,E000) item and the chain must end with the sequence
+ * delimiter exactly at the range end. The fork's hop tolerates malformed item
+ * streams that the full parse rejects (fork #67) — a file failing this check
+ * falls back to a whole read so its error behavior matches a full parse.
  */
-function applyDefinedSkip(state: ReadState, headerEnd: number, valueLength: number): Result<void> {
-    const valueStartInFile = fileOffsetOf(state, headerEnd);
-    if (valueStartInFile + valueLength > state.fileSize) {
-        return err(new Error('declared value length extends beyond EOF'));
-    }
-    state.filePos = valueStartInFile + valueLength;
-    state.assembled = state.assembled.subarray(0, headerEnd);
-    state.growSize = state.chunkBytes;
-    return ok(undefined);
-}
-
-/** Hops encapsulated fragments via 8-byte item headers; returns the file offset after the sequence delimiter. */
-async function hopFragments(handle: FileHandle, start: number, fileSize: number): Promise<Result<number>> {
-    let position = start;
+async function isValidFragmentChain(handle: FileHandle, range: { readonly offset: number; readonly length: number }): Promise<boolean> {
+    const end = range.offset + range.length;
+    let at = range.offset;
     for (let i = 0; i < MAX_FRAGMENT_HOPS; i++) {
-        if (position + 8 > fileSize) {
-            return err(new Error('encapsulated data truncated'));
+        if (at + 8 > end) {
+            return false;
         }
-        const headerResult = await readRange(handle, position, 8);
+        const headerResult = await readRange(handle, at, 8);
         if (!headerResult.ok) {
-            return err(headerResult.error);
+            /* v8 ignore next -- reads inside a fork-measured range cannot fail without concurrent mutation */
+            return false;
         }
         const group = headerResult.value.readUInt16LE(0);
         const elementNum = headerResult.value.readUInt16LE(2);
         const itemLength = headerResult.value.readUInt32LE(4);
         if (group !== 0xfffe) {
-            return err(new Error('unexpected tag between fragments'));
+            return false;
         }
         if (elementNum === 0xe0dd) {
-            return ok(position + 8);
+            return at + 8 === end && itemLength === 0;
         }
         if (elementNum !== 0xe000 || itemLength === UNDEFINED_LENGTH) {
-            return err(new Error('malformed fragment item'));
+            return false;
         }
-        position += 8 + itemLength;
+        at += 8 + itemLength;
     }
     /* v8 ignore next -- requires >100k fragments in one element */
-    return err(new Error('fragment count exceeded bound'));
+    return false;
 }
 
-/** Applies an encapsulated skip: hop the fragments in the file, then truncate after the (rewritten) header. */
-async function applyEncapsulatedSkip(state: ReadState, headerEnd: number): Promise<Result<void>> {
-    const valueStartInFile = fileOffsetOf(state, headerEnd);
-    const afterDelimiter = await hopFragments(state.handle, valueStartInFile, state.fileSize);
-    if (!afterDelimiter.ok) {
-        return err(afterDelimiter.error);
+/** Validates every encapsulated bulk range; any malformed chain forces a whole read. */
+async function encapsulatedRangesValid(handle: FileHandle, head: HeadResult): Promise<boolean> {
+    for (const range of head.bulk.values()) {
+        if (range.encapsulated === true && !(await isValidFragmentChain(handle, range))) {
+            return false;
+        }
     }
-    state.filePos = afterDelimiter.value;
-    state.assembled = state.assembled.subarray(0, headerEnd);
-    state.growSize = state.chunkBytes;
-    return ok(undefined);
-}
-
-/** Appends the next chunk of file bytes to the assembled buffer, doubling the grow size. */
-async function appendChunk(state: ReadState): Promise<Result<void>> {
-    const length = Math.min(state.growSize, state.fileSize - state.filePos);
-    /* v8 ignore next 2 -- decision functions never grow when the file is exhausted */
-    if (length <= 0) return err(new Error('no bytes left to grow'));
-    const chunk = await readRange(state.handle, state.filePos, length);
-    if (!chunk.ok) {
-        return err(chunk.error);
-    }
-    state.assembled = Buffer.concat([state.assembled, chunk.value]);
-    state.filePos += length;
-    state.growSize = Math.min(state.growSize * 2, state.fileSize);
-    return ok(undefined);
+    return true;
 }
 
 // ---------------------------------------------------------------------------
 // Orchestration
 // ---------------------------------------------------------------------------
 
-/** Applies one decision to the state. 'continue' means probe again; anything else ends the loop. */
-async function applyAction(action: ProbeAction, state: ReadState): Promise<'continue' | 'done' | 'fullRead'> {
-    switch (action.kind) {
-        case 'done':
-            return 'done';
-        case 'fullRead':
-            return 'fullRead';
-        case 'grow':
-            return (await appendChunk(state)).ok ? 'continue' : 'fullRead';
-        case 'skipDefined':
-            return applyDefinedSkip(state, action.headerEnd, action.valueLength).ok ? 'continue' : 'fullRead';
-        case 'skipEncapsulated':
-            return (await applyEncapsulatedSkip(state, action.headerEnd)).ok ? 'continue' : 'fullRead';
-    }
-}
-
-/** Runs the probe/skip/grow loop until the file is consumed or a fallback is needed. */
-async function boundedLoop(state: ReadState): Promise<Result<Buffer> | 'fullRead'> {
-    for (let i = 0; i < MAX_ITERATIONS; i++) {
-        const abort = checkAbort(state);
-        if (abort !== undefined) {
-            return err(abort);
-        }
-        const probe = probeParse(state.assembled);
-        const action = probe.threw ? decideAfterThrow(probe, state) : decideAfterSuccess(probe, state);
-        const outcome = await applyAction(action, state);
-        if (outcome === 'done') {
-            return ok(state.assembled);
-        }
-        if (outcome === 'fullRead') {
-            return 'fullRead';
-        }
-    }
-    /* v8 ignore next -- requires >10k skip/grow rounds in one file */
-    return 'fullRead';
-}
-
 /** Reads the whole file through the open handle. */
-async function readWhole(handle: FileHandle, fileSize: number, state: Pick<ReadState, 'deadline' | 'signal' | 'timeoutMs'>): Promise<Result<Buffer>> {
-    const abort = checkAbort(state);
+async function readWhole(handle: FileHandle, fileSize: number, guard: Guard): Promise<Result<Buffer>> {
+    const abort = checkAbort(guard);
     if (abort !== undefined) {
         return err(abort);
     }
     return readRange(handle, 0, fileSize);
 }
 
+/** Discovery + safety checks: the head result, or undefined when elision must not be used. */
+async function usableHead(handle: FileHandle, fileSize: number): Promise<HeadResult | undefined> {
+    let head: HeadResult;
+    try {
+        head = await discoverHead(handle, fileSize);
+    } catch {
+        return undefined;
+    }
+    if (!headUsable(head) || (await hasDefinedLengthEncapsulation(handle, head)) || !(await encapsulatedRangesValid(handle, head))) {
+        return undefined;
+    }
+    return head;
+}
+
 /** Bounded read implementation once the file handle is open. */
 async function readWithHandle(handle: FileHandle, options: BoundedReadOptions): Promise<Result<Buffer>> {
     const fileSize = (await handle.stat()).size;
-    const deadline = Date.now() + options.timeoutMs;
-    const guard = { deadline, signal: options.signal, timeoutMs: options.timeoutMs };
+    const guard: Guard = { deadline: Date.now() + options.timeoutMs, timeoutMs: options.timeoutMs, signal: options.signal };
     const threshold = options.thresholdBytes ?? BOUNDED_READ_THRESHOLD_BYTES;
-    const chunkBytes = options.chunkBytes ?? BOUNDED_READ_CHUNK_BYTES;
+    const abort = checkAbort(guard);
+    if (abort !== undefined) {
+        return err(abort);
+    }
     if (fileSize <= threshold) {
         return readWhole(handle, fileSize, guard);
     }
-    const headResult = await readRange(handle, 0, Math.min(chunkBytes, fileSize));
-    /* v8 ignore next 3 -- the stat already succeeded; a failing head read implies a concurrent truncation */
-    if (!headResult.ok) {
-        return err(headResult.error);
-    }
-    const meta = probeMeta(headResult.value);
-    if (meta === undefined || meta.transferSyntax === TS_DEFLATED_LE) {
+    const head = await usableHead(handle, fileSize);
+    if (head === undefined) {
         return readWhole(handle, fileSize, guard);
     }
-    const state: ReadState = {
-        handle,
-        fileSize,
-        chunkBytes,
-        explicitVr: meta.transferSyntax !== TS_IMPLICIT_LE,
-        bigEndian: meta.transferSyntax === TS_EXPLICIT_BE,
-        metaEnd: meta.metaEnd,
-        deadline,
-        timeoutMs: options.timeoutMs,
-        signal: options.signal,
-        assembled: headResult.value,
-        filePos: headResult.value.length,
-        growSize: chunkBytes,
-    };
-    const result = await boundedLoop(state);
-    if (result === 'fullRead') {
+    const assembled = await assemble(handle, fileSize, head, guard);
+    if (!assembled.ok) {
+        if (assembled.error.message.startsWith('aborted') || assembled.error.message.startsWith('timed out')) {
+            return err(assembled.error);
+        }
+        /* v8 ignore next 2 -- IO failures mid-assembly require concurrent file mutation */
         return readWhole(handle, fileSize, guard);
     }
-    return result;
+    return assembled;
 }
 
 /**

--- a/src/tools/_p10ToJson.test.ts
+++ b/src/tools/_p10ToJson.test.ts
@@ -132,11 +132,11 @@ describe('parseDicomBuffer — binary numeric VRs', () => {
         expect(data['00720083']).toEqual({ vr: 'UV', Value: [42] });
     });
 
-    it('fails gracefully on explicit-VR SV values (known dicom-parser limitation)', () => {
+    it('parses explicit-VR SV values (fixed by @ubercode/dicom-parser — was a dicom-parser@1.8 limitation)', () => {
         const sv = Buffer.alloc(8);
         sv.writeBigInt64LE(-42n, 0);
-        const result = parseDicomBuffer(p10(TS.explicitLE, [explicitEl('00720082', 'SV', sv)]));
-        expect(result.ok).toBe(false);
+        const data = parse(p10(TS.explicitLE, [explicitEl('00720082', 'SV', sv)]));
+        expect(data['00720082']).toEqual({ vr: 'SV', Value: [-42] });
     });
 
     it('parses AT values as GGGGEEEE strings', () => {

--- a/src/tools/_p10ToJson.ts
+++ b/src/tools/_p10ToJson.ts
@@ -17,8 +17,8 @@
  */
 
 import { inflateRawSync } from 'node:zlib';
-import dicomParser from 'dicom-parser';
-import type { DataSet, Element } from 'dicom-parser';
+import dicomParser from '@ubercode/dicom-parser/compat';
+import type { DataSet, Element } from '@ubercode/dicom-parser/compat';
 import { stderr } from 'stderr-lib';
 import type { Result } from '../types';
 import { ok, err } from '../types';
@@ -380,7 +380,11 @@ function parseDicomBuffer(buffer: Uint8Array, options?: P10ParseOptions): Result
             return err(converted.error);
         }
     }
-    return ok({ data, warnings: [...dataSet.warnings, ...mislabel.warnings] });
+    // The fork's core carries its own UTF-8 mislabel detection (its C4, ported
+    // from our #34) with 'x'-prefixed lowercase tags. Ours is the documented
+    // format on this API and honors utf8MislabelPromote — drop the duplicates.
+    const tokenizerWarnings = dataSet.warnings.filter(w => !w.startsWith('possible UTF-8 mislabel: x'));
+    return ok({ data, warnings: [...tokenizerWarnings, ...mislabel.warnings] });
 }
 
 export { parseDicomBuffer, implicitVrLookup };

--- a/test/integration/tools/boundedRead.integration.test.ts
+++ b/test/integration/tools/boundedRead.integration.test.ts
@@ -35,7 +35,7 @@ describe('readDicomHead — differential vs full read (all samples)', () => {
 
     it.each(samples.map(f => [f.slice(SAMPLES_ROOT.length + 1), f]))('%s', async (_label, filePath) => {
         const full = readFileSync(filePath);
-        const bounded = await readDicomHead(filePath, { timeoutMs: 30_000, thresholdBytes: 0, chunkBytes: 4_096 });
+        const bounded = await readDicomHead(filePath, { timeoutMs: 30_000, thresholdBytes: 0 });
         expect(bounded.ok).toBe(true);
         if (!bounded.ok) return;
 
@@ -52,7 +52,7 @@ describe('readDicomHead — differential vs full read (all samples)', () => {
         let boundedTotal = 0;
         let fileTotal = 0;
         for (const filePath of samples) {
-            const bounded = await readDicomHead(filePath, { timeoutMs: 30_000, thresholdBytes: 0, chunkBytes: 4_096 });
+            const bounded = await readDicomHead(filePath, { timeoutMs: 30_000, thresholdBytes: 0 });
             if (bounded.ok) {
                 boundedTotal += bounded.value.length;
                 fileTotal += statSync(filePath).size;


### PR DESCRIPTION
## Summary

Closes #39 — the adoption tracked since the fork review. `dicom-parser@1.8.21` → `@ubercode/dicom-parser@2.0.0-rc.2`.

- **`_p10ToJson`**: import swap to the fork's `/compat` facade; converter unchanged. The fork core's own UTF-8 mislabel warnings (its port of our #34, `x`-prefixed tag format) are filtered so this library's documented warning format stays canonical.
- **`_boundedRead`**: rewritten on `parseHeadAsync` (fork #59/#63/#65). Discovery runs on the real tokenizer over ranged reads; we only assemble the synthetic zero-length-header buffer from the reported bulk ranges — same buffer shape, same converter, no more chunk-probe heuristics. `chunkBytes` knob removed.
- **Safety fallbacks preserved**: truncated files, parse failures, deflated TS, defined-length encapsulated pixel data, and — new — a strict fragment-chain validation of every encapsulated range before elision, defending against fork [#67](https://github.com/MichaelLeeHobbs/dicomParser/issues/67) (its hop tolerates malformed item streams the full parse rejects; filed upstream with repro).

## Behavior changes (CHANGELOG + ADR 006 addendum)

- Explicit-VR `SV`/`UV`/`OV` files now parse natively — former known limitation removed.
- Truncated-mid-value files parse with an `unexpected-eof` warning instead of failing (fork salvage-and-warn posture; divergence A1, deliberate).

## Verification

- 2155 unit tests pass (SV limitation test flipped to assert success)
- 200-test forced-bounded differential (bounded vs full, data + warnings) passes
- DCMTK differential integration suite passes
- **ok/err + output contract diff vs published rc.3 over the 201-file corpus including `bad/`: zero flips, zero tag-count diffs, zero warning-count diffs** (the #60 checklist item — the A1 divergence doesn't manifest on this corpus; `bad/` files fail at the header level in both engines)
- Coverage 94.17/88.14 — above thresholds

The `engine: 'dcmtk'` / `dcmtkFallback` safety net remains intact per the fork's runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uPsy9ynEd9gJVHrzprVH2