### PR TITLE
chore(deps): bump @ubercode/dicom-parser to 2.0.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
-- **Parser engine swapped to `@ubercode/dicom-parser@2.0.0-rc.2`**
+- **Parser engine swapped to `@ubercode/dicom-parser` (2.0.0-rc.2, since bumped to 2.0.0-rc.3)**
   ([#39](https://github.com/MichaelLeeHobbs/dcmtk.js/issues/39)) — the maintained TypeScript
   fork of `dicom-parser`, consumed via its v1-compatible `/compat` facade. Verified: zero
-  ok/err flips and zero output diffs across the 201-file corpus (incl. `bad/`) vs rc.3, and
+  ok/err flips and zero output diffs across the 201-file corpus (incl. `bad/`) vs the
+  published `@ubercode/dcmtk@1.0.0-rc.3`, and
   the full DCMTK differential passes. User-visible changes:
     - Explicit-VR `SV`/`UV`/`OV` files now parse natively (former known limitation removed).
     - Truncated-mid-value files parse with an `unexpected-eof` warning instead of failing;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     - Explicit-VR `SV`/`UV`/`OV` files now parse natively (former known limitation removed).
     - Truncated-mid-value files parse with an `unexpected-eof` warning instead of failing;
       inspect `warnings` where rejection semantics were relied on.
+- **`@ubercode/dicom-parser` bumped to `2.0.0-rc.3`**: the fork's fragment hop is now a
+  strict recognizer (fork [#67](https://github.com/MichaelLeeHobbs/dicomParser/issues/67)
+  fixed), so head/full identity holds upstream by construction; dcmtk.js's own
+  fragment-chain validation stays as defense-in-depth against regressions.
 - **`_boundedRead` rewritten on the fork's `parseHeadAsync`**: bulk-value discovery now runs
   on the real tokenizer over ranged reads instead of chunk-probe heuristics; dcmtk.js only
   assembles the synthetic buffer from the reported ranges, with a strict fragment-chain

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
         ]
     },
     "dependencies": {
-        "@ubercode/dicom-parser": "2.0.0-rc.2",
+        "@ubercode/dicom-parser": "2.0.0-rc.3",
         "fast-xml-parser": "5.8.0",
         "stderr-lib": "2.2.0",
         "tree-kill": "1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@ubercode/dicom-parser':
-        specifier: 2.0.0-rc.2
-        version: 2.0.0-rc.2
+        specifier: 2.0.0-rc.3
+        version: 2.0.0-rc.3
       fast-xml-parser:
         specifier: 5.8.0
         version: 5.8.0
@@ -548,8 +548,8 @@ packages:
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@ubercode/dicom-parser@2.0.0-rc.2':
-    resolution: {integrity: sha512-ZAyzVI30SS3H50I+JtxYdNXKBCzRD5oMuxVccuu8CYAsWGOxMyfUmr8YRnRS3SSvevFaNiRRZsObr8M5O3AYvw==}
+  '@ubercode/dicom-parser@2.0.0-rc.3':
+    resolution: {integrity: sha512-EpbEdBwby73O8qLqdPpNHE9BkaF3yspPx+cRgtZ+saigsdZZT3Q0JGnYinNmtTwPho13KoAuZTYhFAoQzeAJHw==}
     engines: {node: '>=20.16'}
 
   '@vitest/coverage-v8@4.0.18':
@@ -1772,7 +1772,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@ubercode/dicom-parser@2.0.0-rc.2': {}
+  '@ubercode/dicom-parser@2.0.0-rc.3': {}
 
   '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@25.3.3)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:


### PR DESCRIPTION
Picks up the fork's [#67](https://github.com/MichaelLeeHobbs/dicomParser/issues/67) fix (strict encapsulated fragment hop — head/full identity now holds upstream by construction). Our local fragment-chain validation stays as defense-in-depth.

Verified: fork rc.3 gates green locally + independent 200-file head-vs-full differential (0 diffs); dcmtk.js 2156 unit + 205 integration differential tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uPsy9ynEd9gJVHrzprVH2