### PR TITLE
chore: release v1.0.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [1.0.0-rc.4] - 2026-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.0.0-rc.4] - 2026-07-25
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ubercode/dcmtk",
-    "version": "1.0.0-rc.3",
+    "version": "1.0.0-rc.4",
     "description": "Type-safe Node.js wrapper for DCMTK (DICOM Toolkit) command-line utilities",
     "author": "Michael Lee Hobbs <michael.lee.hobbs@gmail.com> (https://github.com/MichaelLeeHobbs)",
     "license": "MIT",


### PR DESCRIPTION
Version bump to 1.0.0-rc.4 and CHANGELOG promotion of the Unreleased section.

Ships #39/#40/#41: the `@ubercode/dicom-parser` 2.0.0-rc.3 engine adoption (SV/UV/OV support, `_boundedRead` on `parseHeadAsync`, salvage-and-warn for truncated files). This is the build intended for the d-dart soak that gates the fork's 2.0.0 final.

After merge, tagging `v1.0.0-rc.4` triggers the OIDC publish workflow (npm dist-tag `rc`, prerelease GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uPsy9ynEd9gJVHrzprVH2