### PR TITLE
fix(dicom): getString joins multi-valued tags instead of truncating to the first component (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - **`getString` no longer truncates multi-valued tags to their first component**
   ([#43](https://github.com/MichaelLeeHobbs/dcmtk.js/issues/43)). Values are now joined with
-  `\` (the DICOM value-multiplicity delimiter): `(0008,0061) CS [OT\CR]` reads as `'OT\CR'`
-  instead of `'OT'`, and an empty first component (`\OT\`) reads as `'\OT\'` instead of
-  colliding with the missing-tag fallback. Long-standing (0.16.1 truncated too); made visible
-  by the rc.3 parser swap. Applies to `DicomDataset.getString`, `DicomInstance.getString`, and
-  PN tags (Alphabetic components joined). Use `getStrings` for the component array or
-  `getFirstValue` for first-only semantics.
+  `\` (the DICOM value-multiplicity delimiter): `(0008,0061) CS [OT\CR]` reads as the
+  5-character string `OT\CR` instead of `OT`, and an empty first component (`\OT\`) reads as
+  `\OT\` instead of colliding with the missing-tag fallback. Values shown in DICOM notation —
+  in a JS string literal the delimiter is escaped (`'OT\\CR'`). Long-standing (0.16.1
+  truncated too); made visible by the rc.3 parser swap. Applies to `DicomDataset.getString`,
+  `DicomInstance.getString`, and PN tags (Alphabetic components joined). Use `getStrings` for
+  primitive components, `getValue` for PN component objects, or `getFirstValue` for
+  first-only semantics.
 
 ## [1.0.0-rc.4] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`getString` no longer truncates multi-valued tags to their first component**
+  ([#43](https://github.com/MichaelLeeHobbs/dcmtk.js/issues/43)). Values are now joined with
+  `\` (the DICOM value-multiplicity delimiter): `(0008,0061) CS [OT\CR]` reads as `'OT\CR'`
+  instead of `'OT'`, and an empty first component (`\OT\`) reads as `'\OT\'` instead of
+  colliding with the missing-tag fallback. Long-standing (0.16.1 truncated too); made visible
+  by the rc.3 parser swap. Applies to `DicomDataset.getString`, `DicomInstance.getString`, and
+  PN tags (Alphabetic components joined). Use `getStrings` for the component array or
+  `getFirstValue` for first-only semantics.
+
 ## [1.0.0-rc.4] - 2026-07-25
 
 ### Changed

--- a/src/dicom/DicomDataset.test.ts
+++ b/src/dicom/DicomDataset.test.ts
@@ -254,6 +254,41 @@ describe('DicomDataset.getString', () => {
         expect(r.value.getString('00100020', 'fallback')).toBe('fallback');
     });
 
+    it('joins multi-valued tags with backslash (#43)', () => {
+        const r = DicomDataset.fromJson({ '00080061': { vr: 'CS', Value: ['OT', 'CR'] } });
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.value.getString('00080061')).toBe('OT\\CR');
+    });
+
+    it('preserves empty components so present tags never read as missing (#43)', () => {
+        const r = DicomDataset.fromJson({ '00080061': { vr: 'CS', Value: ['', 'OT', ''] } });
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.value.getString('00080061', 'MISSING')).toBe('\\OT\\');
+    });
+
+    it('joins multi-valued PN tags by Alphabetic component (#43)', () => {
+        const r = DicomDataset.fromJson({ '00081060': { vr: 'PN', Value: [{ Alphabetic: 'Doe^Jane' }, { Alphabetic: 'Roe^Richard' }] } });
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.value.getString('00081060')).toBe('Doe^Jane\\Roe^Richard');
+    });
+
+    it('joins multi-valued numeric tags (#43)', () => {
+        const r = DicomDataset.fromJson({ '00201041': { vr: 'DS', Value: [-12.5, 3.25] } });
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.value.getString('00201041')).toBe('-12.5\\3.25');
+    });
+
+    it('null components join as empty, still distinguishable from missing (#43)', () => {
+        const r = DicomDataset.fromJson({ '00080061': { vr: 'CS', Value: [null, 'OT'] } });
+        expect(r.ok).toBe(true);
+        if (!r.ok) return;
+        expect(r.value.getString('00080061', 'MISSING')).toBe('\\OT');
+    });
+
     it('handles PN without Alphabetic component', () => {
         const r = DicomDataset.fromJson({ '00100010': { vr: 'PN', Value: [{ Ideographic: 'Test' }] } });
         if (!r.ok) return;

--- a/src/dicom/DicomDataset.ts
+++ b/src/dicom/DicomDataset.ts
@@ -117,8 +117,8 @@ function extractString(element: DicomJsonElement): string {
     if (values === undefined || values.length === 0) return '';
 
     // both extractors map null/undefined/foreign shapes to '' themselves
-    const parts = values.map(value => (element.vr === 'PN' ? extractPNAlphabetic(value) : primitiveToString(value)));
-    return parts.join('\\');
+    const toString = element.vr === 'PN' ? extractPNAlphabetic : primitiveToString;
+    return values.map(toString).join('\\');
 }
 
 /** Extracts a number from a DicomJsonElement with validation. */
@@ -402,9 +402,10 @@ class DicomDataset {
      * Gets a tag value as a string with optional fallback.
      *
      * Multi-valued tags are joined with `\` (the DICOM value-multiplicity
-     * delimiter), so `(0008,0061) CS [OT\CR]` reads as `'OT\\CR'` — use
-     * {@link getStrings} for the components or {@link getFirstValue} for just
-     * the first. PN (PersonName) values extract the Alphabetic component.
+     * delimiter), so `(0008,0061) CS [OT\CR]` reads as the 5-character string
+     * `OT\CR`. Use {@link getStrings} for primitive components, {@link getValue}
+     * for PN component objects, or {@link getFirstValue} for just the first.
+     * PN values join their Alphabetic components.
      * Returns the fallback (default empty string) if the tag is missing or
      * has no value.
      *

--- a/src/dicom/DicomDataset.ts
+++ b/src/dicom/DicomDataset.ts
@@ -104,16 +104,21 @@ function primitiveToString(value: unknown): string {
     return '';
 }
 
-/** Extracts a string from a DicomJsonElement, handling PN values. */
+/**
+ * Extracts a string from a DicomJsonElement, handling PN values.
+ *
+ * Multi-valued elements join with `\` — the DICOM value-multiplicity
+ * delimiter, matching the on-disk encoding and dcmdump's rendering — so no
+ * component is silently dropped and an empty first component (`\OT\`) stays
+ * distinguishable from a missing tag (#43).
+ */
 function extractString(element: DicomJsonElement): string {
     const values = element.Value;
     if (values === undefined || values.length === 0) return '';
 
-    const first = values[0];
-    if (first === undefined || first === null) return '';
-
-    if (element.vr === 'PN') return extractPNAlphabetic(first);
-    return primitiveToString(first);
+    // both extractors map null/undefined/foreign shapes to '' themselves
+    const parts = values.map(value => (element.vr === 'PN' ? extractPNAlphabetic(value) : primitiveToString(value)));
+    return parts.join('\\');
 }
 
 /** Extracts a number from a DicomJsonElement with validation. */
@@ -396,8 +401,12 @@ class DicomDataset {
     /**
      * Gets a tag value as a string with optional fallback.
      *
-     * Returns the fallback (default empty string) if the tag is missing or has no value.
-     * Handles PN (PersonName) values by extracting the Alphabetic component.
+     * Multi-valued tags are joined with `\` (the DICOM value-multiplicity
+     * delimiter), so `(0008,0061) CS [OT\CR]` reads as `'OT\\CR'` — use
+     * {@link getStrings} for the components or {@link getFirstValue} for just
+     * the first. PN (PersonName) values extract the Alphabetic component.
+     * Returns the fallback (default empty string) if the tag is missing or
+     * has no value.
      *
      * @param tag - A DicomTag `(0010,0010)` or hex string `00100010`
      * @param fallback - Value to return if tag is missing (default: `''`)

--- a/src/dicom/DicomInstance.ts
+++ b/src/dicom/DicomInstance.ts
@@ -265,6 +265,9 @@ class DicomInstance {
     /**
      * Gets a tag value as a string with optional fallback.
      *
+     * Multi-valued tags are joined with `\` (the DICOM value-multiplicity
+     * delimiter); PN values extract the Alphabetic component.
+     *
      * @param tag - A DICOM tag, e.g. `'(0010,0010)'` or `'00100010'`
      * @param fallback - Value to return if tag is missing (default: `''`)
      */


### PR DESCRIPTION
## Summary

Closes #43 (reported from the d-dart rc.4 soak). `extractString` took `Value[0]` only:

- `(0008,0061) CS [OT\CR]` → `'OT'` — every component after the first silently lost
- `CS [\OT\]` → `''` — a present tag indistinguishable from a missing one under the default fallback

Long-standing (0.16.1 truncated too); the rc.3 parser swap made it visible by faithfully producing `['', 'OT', '']` where the old engine returned junk-but-truthy values.

## Fix

Option 1 from the issue (reporter's preference): join with `\` — the DICOM value-multiplicity delimiter, matching the on-disk encoding and dcmdump's rendering. PN values join their Alphabetic components. `getStrings` (component array) and `getFirstValue` (first-only) remain for the other access patterns; TSDoc on both `getString` surfaces now documents the contract.

Internal audit: every internal `getString` consumer (UID/date/PN convenience getters) is a single-valued tag — no behavior change for them. `transformTag` now sees the full joined value, which is more correct for multi-value round-trips through dcmodify.

## Verification

- End-to-end repro from the issue: `CS [OT\CR]` → `'OT\CR'`, `CS [\OT\]` → `'\OT\'` (with fallback NOT taken) through `DicomInstance.open`
- 5 new regression tests (multi-value CS, empty components, PN multi-value, numeric DS, null component)
- 2161 unit tests pass; zero existing tests changed (none codified the truncation); coverage above thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uPsy9ynEd9gJVHrzprVH2