### PR TITLE
chore: release v1.0.0-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.0-rc.5] - 2026-07-25
+
 ### Fixed
 
 - **`getString` no longer truncates multi-valued tags to their first component**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ubercode/dcmtk",
-    "version": "1.0.0-rc.4",
+    "version": "1.0.0-rc.5",
     "description": "Type-safe Node.js wrapper for DCMTK (DICOM Toolkit) command-line utilities",
     "author": "Michael Lee Hobbs <michael.lee.hobbs@gmail.com> (https://github.com/MichaelLeeHobbs)",
     "license": "MIT",


### PR DESCRIPTION
Version bump to 1.0.0-rc.5. Ships the #43 fix (multi-value getString join) so the d-dart soak can continue on a build containing it.

After merge, tagging `v1.0.0-rc.5` triggers the OIDC publish workflow (npm dist-tag `rc`, prerelease GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uPsy9ynEd9gJVHrzprVH2