### PR TITLE
chore: release v1.0.0-rc.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.0-rc.6] - 2026-07-25
+
 ### Fixed
 
 - **`lookupTag` now resolves repeating groups**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@ubercode/dcmtk",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "description": "Type-safe Node.js wrapper for DCMTK (DICOM Toolkit) command-line utilities",
     "author": "Michael Lee Hobbs <michael.lee.hobbs@gmail.com> (https://github.com/MichaelLeeHobbs)",
     "license": "MIT",


### PR DESCRIPTION
Release PR for `v1.0.0-rc.6`.

- `package.json` → `1.0.0-rc.6`
- CHANGELOG `[Unreleased]` block promoted to `[1.0.0-rc.6]`

## Contents

Single change since rc.5 — #48, fixing #47:

- **`lookupTag` resolves repeating groups.** Overlay `(60xx,eeee)`, curve `(50xx,eeee)`, and retired variable-pixel-data `(7Fxx,eeee)` tags all returned `undefined` because they were stored once under the upper bound of their range and looked up by exact key. Also fixes implicit-VR resolution for files carrying overlays (was falling back to `UN`).
- **Dictionary refreshed from upstream DCMTK** (PS3.6-2026c), +443 tags. `dicom.dic` is now vendored and parsed directly, so regeneration works from a clean checkout.
- `THIRD-PARTY-NOTICES.md` reproduces the OFFIS 3-clause BSD notice covering the embedded dictionary, and now ships in the npm tarball.

## Breaking-ish

`lookupTagByName('OverlayRows')` / `lookupTagByKeyword` now report the first tag a repeating group covers — `(6000,0010)` instead of `(60FF,0010)`. Pre-1.0 and the old value was unusable in practice (`60FF` is an odd group, so it can never be a real overlay), but it is a public-API behavior change.

Tag `v1.0.0-rc.6` after merge to publish under the `rc` dist-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)